### PR TITLE
Add field for unions

### DIFF
--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -83,6 +83,7 @@ mutual
     let xs = toList x
         ys = toList y in
     aEquivUnion i ns1 xs ns2 ys
+  aEquivHelper i ns1 (EField x k) ns2 (EField y j) = ?aEquivField
   aEquivHelper _ _ _ _ _ = False
   -- TODO check if assert/equivalent should be in here
 
@@ -249,6 +250,7 @@ mutual
       go : (String, (Maybe (Expr Void))) -> Either Error (String, (Maybe Value))
       go x@(k, Nothing) = Right x
       go (k, Just v) = Right (k, Just !(eval env v))
+  eval env (EField x y) = ?evalField
   eval env (EEmbed (Raw x)) = absurd x
   eval env (EEmbed (Resolved x)) = eval initEnv x
 
@@ -426,6 +428,7 @@ mutual
   readBackTyped ctx (VConst _) (VUnion a) = do
     a' <- traverse (readBackUnion ctx) (toList a)
     Right (EUnion (fromList a'))
+  readBackTyped ctx (VUnion _) (VInject a k b) = do ?rBTInject
   readBackTyped _ t v = Left (ReadBackError ("error reading back: " ++ (show v) ++ " of type: " ++ (show t)))
 
   readBackUnion : Ctx -> (String, Maybe Value) -> Either Error (String, Maybe (Expr Void))
@@ -702,6 +705,6 @@ mutual
       getHighestType (Right (VConst CType)) (Just (VConst Kind)) = Right (VConst Kind)
       getHighestType (Right _) (Just (VConst Sort)) = Right (VConst Sort)
       getHighestType acc@(Right _) _ = acc -- relying on acc starting as (VConst CType)
-
+  synth ctx (EField x k) = ?synthField
   synth ctx (EEmbed (Raw x)) = absurd x
   synth ctx (EEmbed (Resolved x)) = synth initCtx x -- Using initCtx here to ensure fresh context.

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -392,7 +392,7 @@ mutual
     do ty' <- evalClosure ran xVal
        v' <- doApply fun xVal
        body <- readBackTyped ctx' ty' v'
-       eTy <- readBackTyped ctx' (VConst CType) ty' -- TODO check this
+       eTy <- readBackTyped ctx (VConst CType) ty'
        Right (ELam x eTy body)
   readBackTyped ctx ty (VEquivalent x y) = do -- TODO not sure is `ty` correct
     x' <- readBackTyped ctx ty x

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -260,7 +260,7 @@ mutual
       case lookup k x' of
            Nothing => ?error
            (Just Nothing) => Right (VInject (fromList x') k Nothing)
-           (Just (Just v)) => Right (VInject (fromList x') k (Just v))
+           (Just (Just _)) => Right (VPrim $ \u => VInject (fromList x') k (Just u))
   eval env (EField _ k) = do
     ?error
   eval env (EEmbed (Raw x)) = absurd x
@@ -414,6 +414,11 @@ mutual
        b' <- evalClosure bT (VNeutral aT (NVar x))
        b <- readBackTyped (extendCtx ctx x aT) (VConst CType) b'
        Right (EPi x a b)
+  readBackTyped ctx (VPi aT bT) (VHLam i f) =
+    let x = freshen (ctxNames ctx) (closureName bT) in do
+      b' <- evalClosure bT (VNeutral aT (NVar x))
+      case i of
+           Prim => readBackTyped ctx b' (f VPrimVar) -- TODO double check b' here
   readBackTyped ctx (VConst CType) (VList a) = do
     a' <- readBackTyped ctx (VConst CType) a
     Right (EList a')

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -158,7 +158,6 @@ mkEnv ((x, e) :: ctx) =
         (IsA t) => let v = VNeutral t (NVar x) in
                        (x, v) :: env)
 
--- TODO check is there some FP magic for this
 mapUnion : (a -> Either e b) -> (k, Maybe a) -> Either e (k, (Maybe b))
 mapUnion f (k, Just x) =
   Right (k, Just !(f x))
@@ -419,7 +418,7 @@ mutual
     let i' = freshen (ctxNames ctx) i in
     do a <- readBackTyped ctx (VConst CType) ty
        body' <- readBackTyped ctx (VConst CType) (f (VNeutral ty (NVar i')))
-       -- TODO not remotely sure about this ^^^, especially the CType
+       -- CType is _probably_ fine here ^^^^^
        Right (EPi i' a body')
   readBackTyped ctx (VPi aT bT) (VHLam i f) =
     let x = freshen (ctxNames ctx) (closureName bT) in do
@@ -502,8 +501,6 @@ isOptional ctx other = unexpected ctx "Not Optional" other
 isEquivalent : Ctx -> Value -> Either Error (Value, Value)
 isEquivalent ctx (VEquivalent x y) = Right (x, y)
 isEquivalent ctx other = unexpected ctx "Not Equivalent" other
-
-isTermLit : Ctx -> Value -> Either Error ()
 
 isTerm : Ctx -> Value -> Either Error ()
 isTerm _ (VPi _ _) = Right ()

--- a/Idrall/Error.idr
+++ b/Idrall/Error.idr
@@ -18,6 +18,9 @@ data Error
   | AssertError String
   | ListAppendError String
   | ListHeadError String
+  | FieldNotFoundError String
+  | FieldArgMismatchError String
+  | InvalidFieldType String
   | ReadFileError String
   | CyclicImportError String
 
@@ -35,5 +38,7 @@ Show Error where
   show (AssertError str) = "AssertError: " ++ str
   show (ListAppendError str) = "ListAppendError: " ++ str
   show (ListHeadError str) = "ListHeadError: " ++ str
+  show (FieldNotFoundError str) = "FieldNotFoundError: " ++ str
+  show (InvalidFieldType str) = "InvalidFieldType: " ++ str
   show (ReadFileError str) = "ReadFileError: " ++ str
   show (CyclicImportError str) = "CyclicImportError: " ++ str

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -7,6 +7,21 @@ Name : Type
 Name = String
 
 public export
+data FieldName = MkFieldName String
+
+public export
+Show FieldName where
+  show (MkFieldName x) = "(MkFieldName " ++ x
+
+public export
+Eq FieldName where
+  (==) (MkFieldName x) (MkFieldName y) = x == y
+
+public export
+Ord FieldName where
+  compare (MkFieldName x) (MkFieldName y) = compare x y
+
+public export
 Namespace : Type
 Namespace = List (Name, Integer)
 %name Namespace ns1, ns2, ns3
@@ -88,8 +103,8 @@ mutual
     | EOptional (Expr a)
     | ENone (Expr a)
     | ESome (Expr a)
-    | EUnion (SortedMap String (Maybe (Expr a)))
-    | EField (Expr a) String
+    | EUnion (SortedMap FieldName (Maybe (Expr a)))
+    | EField (Expr a) FieldName
     | EEmbed (Import a)
 
 export

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -89,6 +89,7 @@ mutual
     | ENone (Expr a)
     | ESome (Expr a)
     | EUnion (SortedMap String (Maybe (Expr a)))
+    | EField (Expr a) String
     | EEmbed (Import a)
 
 export
@@ -132,6 +133,7 @@ mutual
     show (ENone x) = "(ENone " ++ show x ++ ")"
     show (ESome x) = "(ESome " ++ show x ++ ")"
     show (EUnion x) = "(EUnion " ++ show x ++ ")"
+    show (EField x y) = "(EField " ++ show x ++ " " ++ show y ++ ")"
     show (EEmbed x) = "(EEmbed " ++ show x ++ ")"
 
   -- TODO add Traversible for Expr a

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -131,11 +131,11 @@ field = do
   pure (\e => (EField e i))
 
 table : OperatorTable (Expr ImportStatement)
-table = [ [ Infix appl AssocLeft]
+table = [ [ Postfix field]
+        , [ Infix appl AssocLeft]
         , [ Infix (do (token "->" <|> token "→") ; pure (EPi "_")) AssocLeft ]
         , [ Infix (do token ":"; pure EAnnot) AssocLeft]
         , [ Infix (do (token "===" <|> token "≡"); pure EEquivalent) AssocLeft]
-        , [ Postfix field]
         , [ Prefix (do token "assert"; token ":"; pure EAssert)]
         , [ Infix (do token "&&"; pure EBoolAnd) AssocLeft]
         , [ Infix (do token "#"; pure EListAppend) AssocLeft]]

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -128,7 +128,7 @@ field : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
 field = do
   token "."
   i <- identity
-  pure (\e => (EField e i))
+  pure (\e => (EField e (MkFieldName i)))
 
 table : OperatorTable (Expr ImportStatement)
 table = [ [ Postfix field]
@@ -141,19 +141,19 @@ table = [ [ Postfix field]
         , [ Infix (do token "#"; pure EListAppend) AssocLeft]]
 
 mutual
-  unionSimpleElem : Parser (String, Maybe (Expr ImportStatement))
+  unionSimpleElem : Parser (FieldName, Maybe (Expr ImportStatement))
   unionSimpleElem = do
     k <- identity
-    pure (k, Nothing)
+    pure (MkFieldName k, Nothing)
 
-  unionComplexElem : Parser (String, Maybe (Expr ImportStatement))
+  unionComplexElem : Parser (FieldName, Maybe (Expr ImportStatement))
   unionComplexElem = do
     k <- identity
     token ":"
     e <- expr
-    pure (k, Just e)
+    pure (MkFieldName k, Just e)
 
-  unionElem : Parser (String, Maybe (Expr ImportStatement))
+  unionElem : Parser (FieldName, Maybe (Expr ImportStatement))
   unionElem = unionComplexElem <|> unionSimpleElem
 
   union : Parser (Expr ImportStatement)

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -124,11 +124,18 @@ appl : Parser ((Expr ImportStatement) -> (Expr ImportStatement) -> (Expr ImportS
 appl = do spaces
           pure EApp
 
+field : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
+field = do
+  token "."
+  i <- identity
+  pure (\e => (EField e i))
+
 table : OperatorTable (Expr ImportStatement)
 table = [ [ Infix appl AssocLeft]
         , [ Infix (do (token "->" <|> token "→") ; pure (EPi "_")) AssocLeft ]
         , [ Infix (do token ":"; pure EAnnot) AssocLeft]
         , [ Infix (do (token "===" <|> token "≡"); pure EEquivalent) AssocLeft]
+        , [ Postfix field]
         , [ Prefix (do token "assert"; token ":"; pure EAssert)]
         , [ Infix (do token "&&"; pure EBoolAnd) AssocLeft]
         , [ Infix (do token "#"; pure EListAppend) AssocLeft]]

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -135,6 +135,8 @@ mutual
     let kv = toList x in do
       kv' <- resolveUnion h p kv
       pure (EUnion (fromList kv'))
+  resolve h p (EField x y) = do
+    pure (EField !(resolve h p x) y)
   resolve h p (EEmbed (Raw (LocalFile x))) = resolveLocalFile h p x
   resolve h p (EEmbed (Raw (EnvVar x))) = MkIOEither (pure (Left (ErrorMessage "TODO not implemented")))
   resolve h p (EEmbed (Resolved x)) = MkIOEither (pure (Left (ErrorMessage "Already resolved")))

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -143,8 +143,8 @@ mutual
 
   resolveUnion :  (history : List FilePath) -- TODO try use traverse instead?
                -> Maybe FilePath
-               -> List (String, Maybe (Expr ImportStatement))
-               -> IOEither Error (List (String, Maybe (Expr Void)))
+               -> List (FieldName, Maybe (Expr ImportStatement))
+               -> IOEither Error (List (FieldName, Maybe (Expr Void)))
   resolveUnion h p [] = MkIOEither (pure (Right []))
   resolveUnion h p ((k,v) :: xs) = do
     rest <- resolveUnion h p xs

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -53,7 +53,8 @@ mutual
     | VOptional Ty
     | VNone Ty
     | VSome Ty
-    | VUnion (SortedMap String (Maybe (Value)))
+    | VUnion (SortedMap String (Maybe Value))
+    | VInject (SortedMap String (Maybe Value)) String (Maybe Value)
     | VNeutral Ty Neutral
 
   public export
@@ -91,6 +92,7 @@ mutual
     show (VNone a) = "(VNone " ++ show a ++ ")"
     show (VSome a) = "(VSome " ++ show a ++ ")"
     show (VUnion a) = "(VUnion " ++ show a ++ ")"
+    show (VInject a k v) = "(VUnion " ++ show a ++ " " ++ show k ++ " " ++ show v ++ ")"
     show (VNeutral x y) = "(VNeutral " ++ show x ++ " " ++ show y ++ ")"
 
   public export

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -38,6 +38,7 @@ mutual
   public export
   data Value
     = VLambda Ty Closure
+    | VHLam HLamInfo (Value -> Value)
     | VPi Ty Closure
     | VEquivalent Value Value
     | VAssert Value
@@ -55,7 +56,19 @@ mutual
     | VSome Ty
     | VUnion (SortedMap String (Maybe Value))
     | VInject (SortedMap String (Maybe Value)) String (Maybe Value)
+    | VPrimVar
     | VNeutral Ty Neutral
+
+  public export
+  data HLamInfo
+    = Prim
+
+  Show HLamInfo where
+    show Prim = "Prim"
+
+  public export
+  VPrim : (Value -> Value) -> Value
+  VPrim f = VHLam Prim f
 
   public export
   data Neutral
@@ -76,6 +89,7 @@ mutual
   public export
   Show Value where
     show (VLambda x y) = "(VLambda " ++ show x ++ " " ++ show y ++ ")"
+    show (VHLam i x) = "(VHLam " ++ show i ++ " " ++ "TODO find some way to show" ++ ")"
     show (VPi x y) = "(VPi " ++ show x ++ " " ++ show y ++ ")"
     show (VEquivalent x y) = "(VEquivalent " ++ show x ++ " " ++ show y ++ ")"
     show (VAssert x) = "(VEquivalent " ++ show x ++ ")"
@@ -93,6 +107,7 @@ mutual
     show (VSome a) = "(VSome " ++ show a ++ ")"
     show (VUnion a) = "(VUnion " ++ show a ++ ")"
     show (VInject a k v) = "(VUnion " ++ show a ++ " " ++ show k ++ " " ++ show v ++ ")"
+    show (VPrimVar) = "VPrimVar"
     show (VNeutral x y) = "(VNeutral " ++ show x ++ " " ++ show y ++ ")"
 
   public export

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -89,7 +89,7 @@ mutual
   public export
   Show Value where
     show (VLambda x y) = "(VLambda " ++ show x ++ " " ++ show y ++ ")"
-    show (VHLam i x) = "(VHLam " ++ show i ++ " " ++ "TODO find some way to show" ++ ")"
+    show (VHLam i x) = "(VHLam " ++ show i ++ " " ++ "TODO find some way to show VHLam arg" ++ ")"
     show (VPi x y) = "(VPi " ++ show x ++ " " ++ show y ++ ")"
     show (VEquivalent x y) = "(VEquivalent " ++ show x ++ " " ++ show y ++ ")"
     show (VAssert x) = "(VEquivalent " ++ show x ++ ")"

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -56,7 +56,7 @@ mutual
     | VNone Ty
     | VSome Ty
     | VUnion (SortedMap String (Maybe Value))
-    | VInject (SortedMap String (Maybe Value)) String (Maybe Value)
+    | VInject (SortedMap String (Maybe Value)) String (Maybe Value) -- TODO proof that key is in SM?
     | VPrimVar
     | VNeutral Ty Neutral
 

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -40,6 +40,7 @@ mutual
     = VLambda Ty Closure
     | VHLam HLamInfo (Value -> Value)
     | VPi Ty Closure
+    | VHPi String Value (Value -> Value)
     | VEquivalent Value Value
     | VAssert Value
     | VConst U
@@ -71,6 +72,10 @@ mutual
   VPrim f = VHLam Prim f
 
   public export
+  vFun : Value -> Value -> Value
+  vFun a b = VHPi "_" a (\_ => b)
+
+  public export
   data Neutral
     = NVar Name
     | NNaturalIsZero Neutral
@@ -91,6 +96,7 @@ mutual
     show (VLambda x y) = "(VLambda " ++ show x ++ " " ++ show y ++ ")"
     show (VHLam i x) = "(VHLam " ++ show i ++ " " ++ "TODO find some way to show VHLam arg" ++ ")"
     show (VPi x y) = "(VPi " ++ show x ++ " " ++ show y ++ ")"
+    show (VHPi i x y) = "(VHPi " ++ show i ++ " " ++ show x ++ "TODO find some way to show VHPi arg" ++ ")"
     show (VEquivalent x y) = "(VEquivalent " ++ show x ++ " " ++ show y ++ ")"
     show (VAssert x) = "(VEquivalent " ++ show x ++ ")"
     show (VConst x) = "(VConst " ++ show x ++ ")"

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -55,8 +55,8 @@ mutual
     | VOptional Ty
     | VNone Ty
     | VSome Ty
-    | VUnion (SortedMap String (Maybe Value))
-    | VInject (SortedMap String (Maybe Value)) String (Maybe Value) -- TODO proof that key is in SM?
+    | VUnion (SortedMap FieldName (Maybe Value))
+    | VInject (SortedMap FieldName (Maybe Value)) FieldName (Maybe Value) -- TODO proof that key is in SM?
     | VPrimVar
     | VNeutral Ty Neutral
 

--- a/tests/Test.idr
+++ b/tests/Test.idr
@@ -95,7 +95,7 @@ testAll = do
       putStrLn "done"
 
 expectPass : List String
-expectPass = ["AssertTrivial", "Bool", "Function", "Natural", "True", "NaturalIsZero", "NaturalLiteral", "Let", "FunctionTypeTermTerm", "FunctionApplication", "Equivalence", "FunctionDependentType1", "List", "ListLiteralOne", "ListLiteralEmpty", "ListHead", "OperatorListConcatenate", "Optional", "None", "SomeTrue", "Integer", "IntegerLiteral", "IntegerNegate", "UnionTypeType", "UnionTypeOne", "UnionTypeMixedKinds4", "UnionTypeMixedKinds3", "UnionTypeMixedKinds2", "UnionTypeMixedKinds1", "UnionTypeKind", "UnionTypeEmpty" ]
+expectPass = ["AssertTrivial", "Bool", "Function", "Natural", "True", "NaturalIsZero", "NaturalLiteral", "Let", "FunctionTypeTermTerm", "FunctionApplication", "Equivalence", "FunctionDependentType1", "List", "ListLiteralOne", "ListLiteralEmpty", "ListHead", "OperatorListConcatenate", "Optional", "None", "SomeTrue", "Integer", "IntegerLiteral", "IntegerNegate", "UnionTypeType", "UnionTypeOne", "UnionTypeMixedKinds4", "UnionTypeMixedKinds3", "UnionTypeMixedKinds2", "UnionTypeMixedKinds1", "UnionTypeKind", "UnionTypeEmpty", "UnionConstructorField", "UnionConstructorEmptyField"]
 
 testGood : IO ()
 testGood


### PR DESCRIPTION
Added the `.` (field) operator for unions. Depends on #8 

Commit [`62a30be`](https://github.com/alexhumphreys/idrall/pull/9/commits/62a30be57c859e5228f0ee5d89dfba1d454f039e) is an interesting on here. I added `VHLam` and `VHPi` for handling fields. I thought I could get away with letting the parser handling union constructor with arguments, but that wouldn't handle the following case:
```dhall
let x = <Foo : Text>
let y = x.Foo
in y "bar"
```
So since the apply operator needed to know about field application, and I'd need to synth some complicated types, it seemed easier to add `VHLam` and `VHPi`. My thinking is the `VH*` stuff is for built ins, or things constructed during type synthesis, and `VLam` and `VPi` are for actual lambdas found in the user provided dhall expressions. Both `VPi` and `VHPi` get read back as `EPi`, so the should be possible to compare.