### PR TITLE
Add combine and combineTypes

### DIFF
--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -396,9 +396,9 @@ mutual
 
   doCombine : Value -> Value -> Either Error Value
   doCombine (VRecordLit x) (VRecordLit y) =
-    Right (VRecordLit $ !(mergeWith doCombine x y))
+    Right (VRecordLit $ !(mergeWithApp doCombine x y))
   doCombine (VRecord x) (VRecord y) =
-    Right (VRecord $ !(mergeWith doCombine x y))
+    Right (VRecord $ !(mergeWithApp doCombine x y))
   doCombine (VNeutral (VRecord x) v) y =
     -- won't know type of y here, might need to remove some types from rbt
     -- TODO will use an empty list for now
@@ -884,7 +884,7 @@ mutual
     yty <- synth ctx y
     xSm <- isRecord ctx xty
     ySm <- isRecord ctx yty
-    Right $ VRecord !(mergeWith doCombine xSm ySm)
+    Right $ VRecord !(mergeWithApp doCombine xSm ySm)
   synth ctx (ECombineTypes x y) = do
     xV <- eval (mkEnv ctx) x
     yV <- eval (mkEnv ctx) y

--- a/Idrall/Error.idr
+++ b/Idrall/Error.idr
@@ -19,6 +19,8 @@ data Error
   | FieldNotFoundError String
   | FieldArgMismatchError String
   | InvalidFieldType String
+  | CombineError String
+  | RecordFieldCollision String
   | ReadFileError String
   | CyclicImportError String
 
@@ -39,5 +41,7 @@ Show Error where
   show (FieldNotFoundError str) = "FieldNotFoundError: " ++ str
   show (FieldArgMismatchError str) = "FieldArgMismatchError: " ++ str
   show (InvalidFieldType str) = "InvalidFieldType: " ++ str
+  show (CombineError str) = "CombineError: " ++ str
+  show (RecordFieldCollision str) = "RecordFieldCollision: " ++ str
   show (ReadFileError str) = "ReadFileError: " ++ str
   show (CyclicImportError str) = "CyclicImportError: " ++ str

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -13,7 +13,7 @@ data FieldName = MkFieldName String
 
 public export
 Show FieldName where
-  show (MkFieldName x) = "(MkFieldName " ++ x
+  show (MkFieldName x) = "(MkFieldName " ++ show x ++ ")"
 
 public export
 Eq FieldName where
@@ -122,6 +122,10 @@ mutual
     | ERecord (SortedMap FieldName (Expr a))
     -- | > ERecordLit (fromList ((MkFieldName "Foo"), EBool)) ~ { Foo = Bool }
     | ERecordLit (SortedMap FieldName (Expr a))
+    -- | > x /\ y
+    | ECombine (Expr a) (Expr a)
+    -- | > x //\\ y
+    | ECombineTypes (Expr a) (Expr a)
     -- | > EUnion (fromList ((MkFieldName "Foo"), Nothing)) ~ < Foo >
     -- | > EUnion (fromList ((MkFieldName "Foo"), Just EBool)) ~ < Foo : Bool >
     | EUnion (SortedMap FieldName (Maybe (Expr a)))
@@ -140,7 +144,6 @@ mutual
     show (Raw x) = "(Raw)" -- TODO show x
     show (Resolved x) = "(Resolved " ++ show x ++ ")"
 
-  covering -- TODO Maybe idris2 thinks this is total?
   export
   Show (Expr a) where
     show (EVar x) = "(EVar " ++ show x ++ ")"
@@ -176,6 +179,8 @@ mutual
     show (ESome x) = "(ESome " ++ show x ++ ")"
     show (ERecord x) = "(ERecord " ++ show x ++ ")"
     show (ERecordLit x) = "(ERecordLit " ++ show x ++ ")"
+    show (ECombine x y) = "(ECombine " ++ show x ++ " " ++ show y ++ ")"
+    show (ECombineTypes x y) = "(ECombineTypes " ++ show x ++ " " ++ show y ++ ")"
     show (EUnion x) = "(EUnion " ++ show x ++ ")"
     show (EField x y) = "(EField " ++ show x ++ " " ++ show y ++ ")"
     show (EEmbed x) = "(EEmbed " ++ show x ++ ")"

--- a/Idrall/Map.idr
+++ b/Idrall/Map.idr
@@ -1,0 +1,67 @@
+module Idrall.Map
+
+-- helper functions for Map and SortedMap
+
+import Idrall.Expr
+import Idrall.Error
+import Idrall.Value
+
+import Data.List
+
+export
+mapChunks : (a -> Either e b) -> (k, a) -> Either e (k, b)
+mapChunks f (k, a) = Right (k, !(f a))
+
+export
+mapListEither : List a -> (a -> Either e b) -> Either e (List b)
+mapListEither [] f = Right []
+mapListEither (x :: xs) f =
+  do rest <- mapListEither xs f
+     x' <- f x
+     Right (x' :: rest)
+
+export
+mapRecord : (a -> Either e b) -> (k, a) -> Either e (k, b)
+mapRecord f (k, x) = Right (k, !(f x))
+
+export
+mapUnion : (a -> Either e b) -> (k, Maybe a) -> Either e (k, (Maybe b))
+mapUnion f (k, Just x) =
+  Right (k, Just !(f x))
+mapUnion f (k, Nothing) = Right (k, Nothing)
+
+-- Errors on collision
+export
+mergeWith : Show k => Eq k => Ord k =>
+            (Value -> Value -> Either Error Value) ->
+            SortedMap k Value ->
+            SortedMap k Value ->
+            Either Error (SortedMap k Value)
+mergeWith f x y =
+  let xs = Data.SortedMap.toList x
+      ys = Data.SortedMap.toList y in
+  Right $ fromList !(combineLists xs ys)
+where
+  replaceWith : (k, Value) -> List (k, Value) -> List (k, Value)
+  replaceWith (k, v) xs =
+    let rem = filter (\(k',_) => not (k == k')) xs in
+    (k, v) :: rem
+
+  combineLists : List (k, Value) -> List (k, Value) -> Either Error (List (k, Value))
+  combineLists xs [] = Right xs
+  combineLists [] ys = Right ys
+  combineLists xs ((k, y) :: ys) = do
+    rest <- combineLists xs ys
+    case lookup k rest of
+         Nothing => Right $ (k, y) :: rest
+         (Just x) =>
+            case (x, y) of
+                 (VRecord x', VRecord y') => let nested = !(f x y)
+                                                 newKv = (k, nested)
+                                                 res = replaceWith newKv rest in
+                                                 pure res
+                 (VRecordLit x', VRecordLit y') => let nested = !(f x y)
+                                                       newKv = (k, nested)
+                                                       res = replaceWith newKv rest in
+                                                       pure res
+                 (w, q) => Left $ RecordFieldCollision (show k ++ " when combining " ++ (show w) ++ "<>" ++ (show q))

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -203,7 +203,11 @@ table = [ [ Postfix field]
         , [ Infix (do (token "===" <|> token "≡"); pure EEquivalent) AssocLeft]
         , [ Prefix (do token "assert"; token ":"; pure EAssert)]
         , [ Infix (do token "&&"; pure EBoolAnd) AssocLeft]
-        , [ Infix (do token "#"; pure EListAppend) AssocLeft]]
+        , [ Infix (do token "#"; pure EListAppend) AssocLeft]
+        , [ Infix (do pure ECombine <* (token "/\\" <|> token "∧")) AssocLeft
+          , Infix (do pure ECombineTypes <* (token "//\\\\" <|> token "⩓")) AssocLeft
+          ]
+        ]
 
 mutual
   recordTypeElem : Parser (FieldName, Expr ImportStatement)

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -147,6 +147,14 @@ mutual
     let kv = toList x in do
       kv' <- resolveRecord h p kv
       pure (ERecordLit (fromList kv'))
+  resolve h p (ECombine x y) = do
+    x' <- resolve h p x
+    y' <- resolve h p y
+    pure (ECombine x' y')
+  resolve h p (ECombineTypes x y) = do
+    x' <- resolve h p x
+    y' <- resolve h p y
+    pure (ECombineTypes x' y')
   resolve h p (EUnion x) =
     let kv = toList x in do
       kv' <- resolveUnion h p kv

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -85,9 +85,10 @@ mutual
     | NOptional Neutral
     | NNone Neutral
     | NSome Neutral
+    | NCombine Neutral Normal
+    | NCombineTypes Neutral Normal
 
 mutual
-  covering
   public export
   Show Normal where
     show (Normal' x y) = "(Normal' " ++ (show x) ++ " " ++ show y ++ ")"
@@ -129,8 +130,8 @@ mutual
     show (VOptional a) = "(VOptional " ++ show a ++ ")"
     show (VNone a) = "(VNone " ++ show a ++ ")"
     show (VSome a) = "(VSome " ++ show a ++ ")"
-    show (VRecord a) = "(VRecord " ++ show a ++ ")"
-    show (VRecordLit a) = "(VRecordLit " ++ show a ++ ")"
+    show (VRecord a) = "(VRecord $ " ++ show a ++ ")"
+    show (VRecordLit a) = "(VRecordLit $ " ++ show a ++ ")"
     show (VUnion a) = "(VUnion " ++ show a ++ ")"
     show (VInject a k v) = "(VUnion " ++ show a ++ " " ++ show k ++ " " ++ show v ++ ")"
     show (VPrimVar) = "VPrimVar"
@@ -151,6 +152,8 @@ mutual
     show (NNone x) = "(NNone " ++ show x ++ ")"
     show (NSome x) = "(NSome " ++ show x ++ ")"
     show (NBoolAnd x y) = "(NBoolAnd " ++ show x ++ " " ++ show y ++ ")"
+    show (NCombine x y) = "(NCombine " ++ show x ++ " " ++ show y ++ ")"
+    show (NCombineTypes x y) = "(NCombineTypes " ++ show x ++ " " ++ show y ++ ")"
 
 public export
 Semigroup VChunks where

--- a/idrall.ipkg
+++ b/idrall.ipkg
@@ -11,6 +11,7 @@ modules = Idrall.Expr
         , Idrall.Lexer
         , Idrall.Check
         , Idrall.Error
+        , Idrall.Map
         , Idrall.IOEither
         , Idrall.Path
         , Idrall.TestHelper

--- a/tests/idrall/idrall002/expected
+++ b/tests/idrall/idrall002/expected
@@ -96,7 +96,7 @@ Error: ReadFileError: File Not Found //length
 testing: ListLiteralEmpty
 Success: ()
 testing: ListLiteralEmptyNormalizeAnnotation
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName x, (EApp (ELam "listArg1" (EConst CType) (EList (EVar "listArg1"))) EBool))])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "x"), (EApp (ELam "listArg1" (EConst CType) (EList (EVar "listArg1"))) EBool))])
 testing: ListLiteralNormalizeArguments
 Error: MissingVar: "if"
 testing: ListLiteralOne
@@ -194,7 +194,7 @@ Error: ErrorMessage: "Parse failed at position 0: char '('"
 testing: RecordLitDuplicateFieldsNoCollisions
 Error: ErrorMessage: "Parse failed at position 0: char '('"
 testing: RecordLitNormalizeFieldType
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName t, EBool)])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "t"), EBool)])
 testing: RecordLitPun
 Error: ErrorMessage: "Parse failed at position 0: char '('"
 testing: RecordLitPunCapture
@@ -238,11 +238,11 @@ Error: ErrorMessage: "Parse failed at position 25: expected the end of the strin
 testing: RecordProjectionValue
 Error: ErrorMessage: "Parse failed at position 20: expected the end of the string"
 testing: RecordSelectionKind
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName x, (EConst CType))])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "x"), (EConst CType))])
 testing: RecordSelectionType
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName x, (ERecord fromList []))])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "x"), (ERecord fromList []))])
 testing: RecordSelectionValue
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName x, (ERecordLit fromList []))])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "x"), (ERecordLit fromList []))])
 testing: RecordType
 Success: ()
 testing: RecordTypeEmpty
@@ -264,41 +264,41 @@ Success: ()
 testing: RecordTypeType
 Success: ()
 testing: RecursiveRecordMergeBoolType
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeLhsEmpty
-Error: ErrorMessage: "Parse failed at position 4: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeMixedKinds
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeRecursively
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeRecursivelyKinds
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeRecursivelyTypes
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeRhsEmpty
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeTwo
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeTwoKinds
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordMergeTwoTypes
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeDeep
-Error: ErrorMessage: "Parse failed at position 29: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeRecursively
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeRecursivelyKinds
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeRecursivelyTypes
-Error: ErrorMessage: "Parse failed at position 21: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeRhsEmpty
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeTwo
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeTwoKinds
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RecursiveRecordTypeMergeTwoTypes
-Error: ErrorMessage: "Parse failed at position 13: expected the end of the string"
+Success: ()
 testing: RightBiasedRecordMergeMixedKinds
 Error: ErrorMessage: "Parse failed at position 12: expected the end of the string"
 testing: RightBiasedRecordMergeRhsEmpty
@@ -338,7 +338,7 @@ Success: ()
 testing: TypeAnnotationFunction
 Success: ()
 testing: TypeAnnotationNormalize
-Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName x, EBool)])
+Error: InvalidFieldType: (ERecordLit fromList [((MkFieldName "x"), EBool)])
 testing: TypeAnnotationSort
 Success: ()
 testing: UnionConstructorEmptyField
@@ -366,7 +366,7 @@ Error: ErrorMessage: "Parse failed at position 0: char '('"
 testing: WithNewType
 Error: ErrorMessage: "Parse failed at position 0: char '('"
 DONE
-Passed: 80
-Failed: 103
+Passed: 98
+Failed: 85
 1/1: Building All (All.idr)
 Main> Main> Bye for now!


### PR DESCRIPTION
Not sure how well I wrote that `mergeWith` function, but it passes the tests (which are now running in CI!). There was already a `mergeWith` function for `SortedMap` but it needed a function `a -> a -> a` and all mine are `a -> a -> Either e  a` so I had to knock this one together.

I also decided to add both `combine` and `combineTypes`, as synthesising the types for `combine` is easier if I can piggyback on the `combineTypes` machinery.