### PR TITLE
Minimum change to make slow

### DIFF
--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -510,8 +510,8 @@ mutual
     a' <- readBackTyped ctx (VConst CType) a
     es <- mapListEither vs (readBackTyped ctx a) -- Passing a here should confirm ty=a
     Right (EListLit (Just a') es)
-  readBackTyped ctx _ (VListFold a b c d e) = Left $ ErrorMessage "ListFold"
   readBackTyped ctx (VConst CType) VText = Right EText
+  readBackTyped ctx _ (VListFold) = Left $ ErrorMessage "ListFold"
   readBackTyped ctx VText (VTextLit (MkVChunks xs x)) =
     let f = mapChunks (readBackTyped ctx VText) in
     do

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -510,6 +510,7 @@ mutual
     a' <- readBackTyped ctx (VConst CType) a
     es <- mapListEither vs (readBackTyped ctx a) -- Passing a here should confirm ty=a
     Right (EListLit (Just a') es)
+  readBackTyped ctx _ (VListFold a b c d e) = Left $ ErrorMessage "ListFold"
   readBackTyped ctx (VConst CType) VText = Right EText
   readBackTyped ctx VText (VTextLit (MkVChunks xs x)) =
     let f = mapChunks (readBackTyped ctx VText) in

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -30,7 +30,7 @@ mutual
     | VDoubleLit Double
     | VList Ty
     | VListLit (Maybe Ty) (List Value)
-    | VListFold Value Value Value Value Value
+    | VListFold
     | VText
     | VTextLit VChunks
     | VOptional Ty
@@ -125,7 +125,7 @@ mutual
     show (VDoubleLit k) = "(VDoubleLit " ++ show k ++ ")"
     show (VList a) = "(VList " ++ show a ++ ")"
     show (VListLit ty vs) = "(VListLit " ++ show ty ++ show vs ++ ")"
-    show (VListFold _ _ _ _ _) = "(VListHead)"
+    show (VListFold) = "(VListHead)"
     show (VText) = "VText"
     show (VTextLit x) = "(VTextLit " ++ show x ++ ")"
     show (VOptional a) = "(VOptional " ++ show a ++ ")"

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -30,6 +30,7 @@ mutual
     | VDoubleLit Double
     | VList Ty
     | VListLit (Maybe Ty) (List Value)
+    | VListFold Value Value Value Value Value
     | VText
     | VTextLit VChunks
     | VOptional Ty
@@ -124,6 +125,7 @@ mutual
     show (VDoubleLit k) = "(VDoubleLit " ++ show k ++ ")"
     show (VList a) = "(VList " ++ show a ++ ")"
     show (VListLit ty vs) = "(VListLit " ++ show ty ++ show vs ++ ")"
+    show (VListFold _ _ _ _ _) = "(VListHead)"
     show (VText) = "VText"
     show (VTextLit x) = "(VTextLit " ++ show x ++ ")"
     show (VOptional a) = "(VOptional " ++ show a ++ ")"


### PR DESCRIPTION
Running
```
time make test INTERACTIVE=''
```
results on master:
```
make test INTERACTIVE=''  18.79s user 1.54s system 93% cpu 21.753 total
```

and on this branch:
```
make test INTERACTIVE=''  43.66s user 2.58s system 96% cpu 47.854 total
```

Running `make make edit-tests` to drop into a repl for one of the tests, running `:exec main` there usually is a pause, and then the output of the test starts appearing super fast. On both branches once the output starts appearing it's quick, but the pause beforehand on master takes like 3~ seconds and on this branch it's like 10~ seconds.

These numbers stay similar even when rebuilding `idris2` from source in the background, so it doesn't seem to be related to what my machine is doing at the time.

- Idris2 version https://github.com/idris-lang/Idris2/commit/a7cb2745bcc7cf6b920ff00eecb18372835c4a06 installed from source.
- Running on mac Catalina.
- Chez Scheme Version 9.5.4, i think installed from homebrew.

Setting `:log 100` on the repl, these lines appear equally fast in both branches:
```
Main> :exec main
LOG elab.ambiguous:10: Only one PrimIO.unsafePerformIO
LOG elab:10: Checking application of PrimIO.unsafePerformIO ($resolved1676) to [main]
	Function type {0 a : Type} -> (1 {arg:431} : (PrimIO.IO a[0])) -> a[1]))
	Expected app type Nothing
LOG unify.meta:5: Adding new meta (Main.{a:2405}, ((interactive):1:1--1:1, Rig0))

<snip>

LOG eval.stuck:5: Stuck function: PrimIO.unsafePerformIO
LOG unify.unsolved:10: Unsolved guesses []
LOG quantity:5: Linearity check on : (PrimIO.unsafePerformIO Builtin.Unit Main.main)
LOG quantity:5: Used: []
LOG quantity:5: Linearity check on : (PrimIO.unsafePerformIO Builtin.Unit Main.main)
LOG quantity:5: Used: []
```
then there's a pause, then the test logs start. It's just that pause that's a different lenth between branches.

UPDATE

Ok, looks like specifically the _order_ of the cases in `readBackTyped` is the issue, if I add this new case at the start or the end, then it goes back to the 15s time. As I add it closer to the middle the time increases to 40~ seconds.

Moving also has a slight effect on type checking speed:
```
idris2 --typecheck idrall.ipkg  5.71s user 0.38s system 98% cpu 6.150 total
idris2 --typecheck idrall.ipkg  4.79s user 0.30s system 98% cpu 5.148 total
```

And checking the file size of the output of:
```
idris2 -p contrib Idrall/Check.idr --client ':di readBackTyped'
```
has a large difference:
```
425K fast.out
1.7M slow.out
```