### PR TITLE
Add List/fold

### DIFF
--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -525,6 +525,13 @@ mutual
 
   covering
   readBackTyped : Ctx -> Ty -> Value -> Either Error (Expr Void)
+  readBackTyped ctx _ (VListFold a l t u v) = do
+    a' <- readBackTyped ctx (VConst CType) a
+    l' <- readBackTyped ctx (VConst CType) l
+    t' <- readBackTyped ctx (VConst CType) t
+    u' <- readBackTyped ctx (VConst CType) u
+    v' <- readBackTyped ctx (VConst CType) v
+    Right $ (EApp (EApp (EApp (EApp (EApp EListFold a') l') t') u') v')
   readBackTyped ctx (VPi dom ran) fun =
     let x = freshen (ctxNames ctx) (closureName ran)
         xVal = VNeutral dom (NVar x)
@@ -584,13 +591,6 @@ mutual
     a' <- readBackTyped ctx (VConst CType) a
     es <- mapListEither vs (readBackTyped ctx a) -- Passing a here should confirm ty=a
     Right (EListLit (Just a') es)
-  readBackTyped ctx _ (VListFold a l t u v) = do
-    a' <- readBackTyped ctx (VConst CType) a
-    l' <- readBackTyped ctx (VConst CType) l
-    t' <- readBackTyped ctx (VConst CType) t
-    u' <- readBackTyped ctx (VConst CType) u
-    v' <- readBackTyped ctx (VConst CType) v
-    Right $ (EApp (EApp (EApp (EApp (EApp EListFold a') l') t') u') v')
   readBackTyped ctx (VConst CType) VText = Right EText
   readBackTyped ctx VText (VTextLit (MkVChunks xs x)) =
     let f = mapChunks (readBackTyped ctx VText) in

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -108,6 +108,8 @@ mutual
     | EListAppend (Expr a) (Expr a)
     -- | > List/Head A [a]
     | EListHead (Expr a) (Expr a)
+    -- | > List/Fold A [a] B (a -> B -> B) b
+    | EListFold
     -- | > EText ~ Text
     | EText
     -- | > ETextLit (Chunks [(t1, e1), (t2, e2)] t3) ~  "t1${e1}t2${e2}t3"
@@ -172,6 +174,7 @@ mutual
     show (EListLit (Just x) xs) = "(EListLit (Just " ++ show x ++ ") " ++ show xs ++ ")"
     show (EListAppend x y) = "(EListAppend " ++ show x ++ " " ++ show y ++ ")"
     show (EListHead x y) = "(EListHead " ++ show x ++ " " ++ show y ++ ")"
+    show EListFold = "EListFold"
     show EText = "EText"
     show (ETextLit x) = "(ETextLit " ++ show x ++ ")"
     show (EOptional x) = "(EOptional " ++ show x ++ ")"

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -40,6 +40,7 @@ builtin : Parser (Expr ImportStatement)
 builtin =
   (string "Integer/negate" *> pure fIntegerNegate) <|>
   (string "Natural/isZero" *> pure fNaturalIsZero) <|>
+  (string "List/fold" *> pure EListFold) <|>
   (string "List/head" *> pure fListHead) <|>
   (string "List" *> pure fList) <|>
   (string "None" *> pure fNone) <|>
@@ -154,6 +155,7 @@ reservedNames' =
   [ "in", "let", "assert"
   , "->", "&&", ":"
   , "List", "Text", "Optional", "Natural", "Integer", "Double"
+  , "List/fold" , "List/head"
   , "Some", "None"
   , "Type", "Kind", "Sort"]
 
@@ -452,10 +454,11 @@ mutual
   opExpr = buildExpressionParser (Expr ImportStatement) table term
 
   expr : Parser (Expr ImportStatement)
-  expr = letExpr <|> pi <|> lam <|> opExpr <|> term
+  expr = letExpr <|> lam <|> opExpr <|> term
 
   parseToEnd : Parser (Expr ImportStatement)
   parseToEnd = do
+    spaces
     e <- expr
     eos
     pure e

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -126,6 +126,7 @@ mutual
     x' <- resolve h p x
     y' <- resolve h p y
     pure (EListHead x' y')
+  resolve h p (EListFold) = pure EListFold
   resolve h p EText = pure EText
   resolve h p (ETextLit (MkChunks xs x)) = do
     xs' <- resolveChunks h p xs

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -31,6 +31,7 @@ mutual
     | VDoubleLit Double
     | VList Ty
     | VListLit (Maybe Ty) (List Value)
+    | VListFold Value Value Value Value Value
     | VText
     | VTextLit VChunks
     | VOptional Ty
@@ -62,6 +63,8 @@ mutual
   public export
   data HLamInfo
     = Prim
+    | Typed String Value
+    | ListFoldCl Value
 
   public export
   VPrim : (Value -> Either Error Value) -> Value
@@ -89,6 +92,10 @@ mutual
   vFun : Value -> Value -> Value
   vFun a b = VHPi "_" a (\_ => b)
 
+  public export
+  vType : Value
+  vType = VConst CType
+
 mutual
   public export
   Show Normal where
@@ -96,6 +103,8 @@ mutual
 
   Show HLamInfo where
     show Prim = "Prim"
+    show (Typed s v) = "(Typed " ++ show s ++ " " ++ show v ++ ")"
+    show (ListFoldCl v) = "(ListFoldCl " ++ show v ++ ")"
 
   public export
   Show Closure where
@@ -126,6 +135,10 @@ mutual
     show (VDoubleLit k) = "(VDoubleLit " ++ show k ++ ")"
     show (VList a) = "(VList " ++ show a ++ ")"
     show (VListLit ty vs) = "(VListLit " ++ show ty ++ show vs ++ ")"
+    show (VListFold v w x y z) =
+      "(VListHead "
+       ++ show v ++ " " ++ show w ++ " " ++ show x ++ " "
+       ++ show y ++ " " ++ show z ++ ")"
     show (VText) = "VText"
     show (VTextLit x) = "(VTextLit " ++ show x ++ ")"
     show (VOptional a) = "(VOptional " ++ show a ++ ")"

--- a/tests/idrall/idrall001/Good.idr
+++ b/tests/idrall/idrall001/Good.idr
@@ -11,7 +11,7 @@ import Data.List
 import Data.Strings
 
 expectPass : List String
-expectPass = ["AssertTrivial", "Bool", "Function", "Natural", "True", "NaturalIsZero", "NaturalLiteral", "Let", "FunctionTypeTermTerm", "FunctionApplication", "Equivalence", "FunctionDependentType1", "List", "ListLiteralOne", "ListLiteralEmpty", "ListHead", "OperatorListConcatenate", "Optional", "None", "SomeTrue", "Integer", "IntegerLiteral", "IntegerNegate", "UnionTypeType", "UnionTypeOne", "UnionTypeMixedKinds4", "UnionTypeMixedKinds3", "UnionTypeMixedKinds2", "UnionTypeMixedKinds1", "UnionTypeKind", "UnionTypeEmpty", "UnionConstructorField", "UnionConstructorEmptyField", "TypeAnnotation", "TypeAnnotationFunction", "TypeAnnotationSort", "Text", "TextLiteral", "TextLiteralWithInterpolation", "Double", "DoubleLiteral"]
+expectPass = ["AssertTrivial", "Bool", "Function", "Natural", "True", "NaturalIsZero", "NaturalLiteral", "Let", "FunctionTypeTermTerm", "FunctionApplication", "Equivalence", "FunctionDependentType1", "List", "ListLiteralOne", "ListLiteralEmpty", "ListHead", "OperatorListConcatenate", "Optional", "None", "SomeTrue", "Integer", "IntegerLiteral", "IntegerNegate", "UnionTypeType", "UnionTypeOne", "UnionTypeMixedKinds4", "UnionTypeMixedKinds3", "UnionTypeMixedKinds2", "UnionTypeMixedKinds1", "UnionTypeKind", "UnionTypeEmpty", "UnionConstructorField", "UnionConstructorEmptyField", "TypeAnnotation", "TypeAnnotationFunction", "TypeAnnotationSort", "Text", "TextLiteral", "TextLiteralWithInterpolation", "Double", "DoubleLiteral", "ListFold"]
 
 testGood : IO ()
 testGood = testAB Z Z expectPass

--- a/tests/idrall/idrall001/expected
+++ b/tests/idrall/idrall001/expected
@@ -80,8 +80,10 @@ testing: Double
 Success: ()
 testing: DoubleLiteral
 Success: ()
+testing: ListFold
+Success: ()
 DONE
-Passed: 41
+Passed: 42
 Failed: 0
 1/1: Building Good (Good.idr)
 Main> Main> Bye for now!

--- a/tests/idrall/idrall002/expected
+++ b/tests/idrall/idrall002/expected
@@ -56,7 +56,7 @@ Success: ()
 testing: If
 Error: MissingVar: "if"
 testing: IfNormalizeArguments
-Error: ErrorMessage: "Parse failed at position 0: char '('"
+Error: MissingVar: "if"
 testing: Integer
 Success: ()
 testing: IntegerClamp
@@ -84,7 +84,7 @@ Success: ()
 testing: ListBuild
 Error: ReadFileError: File Not Found //build
 testing: ListFold
-Error: ReadFileError: File Not Found //fold
+Success: ()
 testing: ListHead
 Success: ()
 testing: ListIndexed
@@ -366,7 +366,7 @@ Error: ErrorMessage: "Parse failed at position 0: char '('"
 testing: WithNewType
 Error: ErrorMessage: "Parse failed at position 0: char '('"
 DONE
-Passed: 98
-Failed: 85
+Passed: 99
+Failed: 84
 1/1: Building All (All.idr)
 Main> Main> Bye for now!


### PR DESCRIPTION
This also includes a big `aEquiv` refactor from `Bool`s to `Either`, which was the long way for me to find a bug in the `aEquivHelper i ns1 (EVar x) ns2 (EVar y)` case: a typo where i compared `i == j` instead of `j == k`.

Also includes a weird performance fix commit, without it the tests go from 15s to 40s (???)

Still not sure I like having the `VHLam` stuff, and that `VListFold` ends up in `Value`...