### PR TITLE
Fix `prelude` test

### DIFF
--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -53,6 +53,7 @@ mutual
     = LocalFile FilePath
     | EnvVar String
     | Http String
+    | Missing
 
   public export
   data Import a
@@ -213,6 +214,7 @@ Show ImportStatement where
   show (LocalFile x) = "(LocalFile " ++ show x ++ ")"
   show (EnvVar x) = "(EnvVar " ++ x ++ ")"
   show (Http x) = "(Http " ++ x ++ ")"
+  show Missing = "Missing"
 
 mutual
   export

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -537,6 +537,11 @@ mutual
     show HTTP = "http://"
     show HTTPS = "https://"
 
+  missingImport : Parser (ImportStatement)
+  missingImport = do
+    string "missing"
+    pure $ Missing
+
   httpImport : Parser (ImportStatement)
   httpImport = do
     protocol <- token "http://" <|> token "https://"
@@ -544,7 +549,7 @@ mutual
     pure $ Http (show protocol ++ rest)
 
   dhallImportStatement : Parser (ImportStatement)
-  dhallImportStatement = httpImport <|> pathTerm
+  dhallImportStatement = httpImport <|> pathTerm <|> missingImport
 
   importAs : Parser (a -> Import a)
   importAs = (token "Text" *> pure Text) <|> (token "Location" *> pure Location)

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -428,6 +428,7 @@ mutual
   letExpr : Parser (Expr ImportStatement)
   letExpr = do
     token "let"
+    optional whitespace
     i <- identity <|> identBackticks
     spaces
     t <- optional (do token ":"; expr)

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -8,8 +8,6 @@ import Idrall.Path
 
 import System.File
 
-import Debug.Trace
-
 parseErrorHandler : String -> Error
 parseErrorHandler x = ErrorMessage (x)
 
@@ -18,7 +16,7 @@ fileErrorHandler x y = ReadFileError (show y ++ " " ++ x)
 
 readFile' : String -> IOEither Error String
 readFile' x =
-  let contents = trace x $ MkIOEither (readFile x) in
+  let contents = MkIOEither (readFile x) in
       mapErr (fileErrorHandler x) contents
 
 nextCurrentPath : (current : Maybe Path) -> (next : Path) -> Path

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -8,6 +8,8 @@ import Idrall.Path
 
 import System.File
 
+import Debug.Trace
+
 parseErrorHandler : String -> Error
 parseErrorHandler x = ErrorMessage (x)
 
@@ -16,7 +18,7 @@ fileErrorHandler x y = ReadFileError (show y ++ " " ++ x)
 
 readFile' : String -> IOEither Error String
 readFile' x =
-  let contents = MkIOEither (readFile x) in
+  let contents = trace x $ MkIOEither (readFile x) in
       mapErr (fileErrorHandler x) contents
 
 nextCurrentPath : (current : Maybe Path) -> (next : Path) -> Path

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -243,6 +243,7 @@ mutual
   resolve h p (EEmbed (Raw (LocalFile x))) = resolveLocalFile h p x
   resolve h p (EEmbed (Raw (EnvVar x))) = MkIOEither (pure (Left (ErrorMessage "TODO Env var imports not implemented")))
   resolve h p (EEmbed (Raw (Http x))) = MkIOEither (pure (Left (ErrorMessage "TODO http imports not implemented")))
+  resolve h p (EEmbed (Raw Missing)) = MkIOEither (pure (Left (ErrorMessage "No valid imports")))
   resolve h p (EEmbed (Text a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Text not implemented")))
   resolve h p (EEmbed (Location a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Location not implemented")))
   resolve h p (EEmbed (Resolved x)) = MkIOEither (pure (Left (ErrorMessage "Already resolved")))

--- a/tests/idrall/idrall002/expected
+++ b/tests/idrall/idrall002/expected
@@ -349,7 +349,7 @@ Testing: ("../../../dhall-lang/tests/type-inference/success", "accessType")
 Testing: ("../../../dhall-lang/tests/type-inference/success", "preferMixedRecords")
 Testing: ("../../../dhall-lang/tests/type-inference/success", "preferMixedRecordsSameField")
 Testing: ("../../../dhall-lang/tests/type-inference/success", "prelude")
-ErrorMessage: "Parse failed at position 604: char '('"
+ErrorMessage: "TODO as Location not implemented"
 Testing: ("../../../dhall-lang/tests/type-inference/success", "recordOfRecordOfTypes")
 Testing: ("../../../dhall-lang/tests/type-inference/success", "recordOfTypes")
 Result: 

--- a/tests/idrall/idrall004/One.idr
+++ b/tests/idrall/idrall004/One.idr
@@ -11,7 +11,7 @@ import Data.List
 import Data.Strings
 
 dirTreeOne : DirTree String
-dirTreeOne = MkDirTree "../../../dhall-lang/tests/type-inference/success" [] ["prelude"]
+dirTreeOne = MkDirTree "../../../dhall-lang/tests/type-inference/success/simple" [] ["toMapEmptyNormalizeAnnotation"]
 
 testGood : IO (Result)
 testGood = runTests dirTreeOne

--- a/tests/idrall/idrall004/One.idr
+++ b/tests/idrall/idrall004/One.idr
@@ -11,7 +11,7 @@ import Data.List
 import Data.Strings
 
 dirTreeOne : DirTree String
-dirTreeOne = MkDirTree "../../../dhall-lang/tests/type-inference/success/simple" [] ["toMapEmptyNormalizeAnnotation"]
+dirTreeOne = MkDirTree "../../../dhall-lang/tests/type-inference/success" [] ["prelude"]
 
 testGood : IO (Result)
 testGood = runTests dirTreeOne


### PR DESCRIPTION
That test infers the type of the entire prelude, so this was mostly fixing the parser so this test would fail with an import error rather than a parser error.