### PR TITLE
Fix derive maybe

### DIFF
--- a/Idrall/Derive.idr
+++ b/Idrall/Derive.idr
@@ -142,8 +142,9 @@ FromDhall a => FromDhall (List a) where
 
 export
 FromDhall a => FromDhall (Maybe a) where
-  fromDhall (ESome x) = pure $ fromDhall x
-  fromDhall ENone = neutral
+  fromDhall (ESome x) =
+    pure $ fromDhall x
+  fromDhall ENone = pure $ neutral
   fromDhall _ = neutral
 
 ||| Used with FromDhall interface, to dervice implementations
@@ -201,8 +202,6 @@ deriveFromDhall it n =
           let rhs = foldr (\(n, type), acc =>
                             let name = primStr $ (show n) in
                                 case type of
-                                     `(Prelude.Types.Maybe _) => do
-                                       `(~acc <*> (pure $ lookup (MkFieldName ~name) ~(var arg) >>= fromDhall))
                                      _ => `(~acc <*> (lookup (MkFieldName ~name) ~(var arg) >>= fromDhall)))
                           `(pure ~(var constructor')) xs
           pure (rhs)
@@ -215,7 +214,6 @@ deriveFromDhall it n =
           in do
           case xs of
                [] => pure $ (lhs, `(pure ~(var constructor')))
-               ((n, `(Prelude.Types.Maybe _)) :: []) => pure $ (lhs, `(pure ~(var constructor') <*> fromDhall ~(var arg)))
                ((n, _) :: []) => pure $ (lhs, `(pure ~(var constructor') <*> fromDhall ~(var arg)))
                (x :: _) => fail $ "too many args for constructor: " ++ show constructor'
     genClauses : IdrisType -> Name -> Name -> Cons -> Elab (List Clause)

--- a/examples/package.dhall
+++ b/examples/package.dhall
@@ -1,5 +1,5 @@
 { package = "myidrispackage"
-, sourcedir = Some "./"
+, sourceDir = Some "./"
 , depends = Some ["contrib"]
 , modules = ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]
 }

--- a/tests/derive/derive001/Derive.idr
+++ b/tests/derive/derive001/Derive.idr
@@ -23,25 +23,27 @@ record ExRec1 where
   lb : List Bool
   st : String
   mst : Maybe String
+  mst2 : Maybe String
   -- a6 : Nat
 
 Show ExRec1 where
-  show (MkExRec1 mn n i b d lb st mst) =
-    "(MkExample3 \{show mn} \{show n} \{show i} \{show b} \{show d} \{show lb} \{show st} \{show mst})"
+  show (MkExRec1 mn n i b d lb st mst mst2) =
+    "(MkExample3 \{show mn} \{show n} \{show i} \{show b} \{show d} \{show lb} \{show st} \{show mst} \{show mst2})"
 
 %runElab (deriveFromDhall Record `{ ExRec1 })
 
 exRec1 : Maybe ExRec1
 exRec1 = fromDhall
   (ERecordLit $
-    fromList [ (MkFieldName "mn", ENaturalLit 3)
+    fromList [ (MkFieldName "mn", ESome $ ENaturalLit 3)
              , (MkFieldName "n", ENaturalLit 4)
              , (MkFieldName "i", EIntegerLit 5)
              , (MkFieldName "b", EBoolLit True)
              , (MkFieldName "d", EDoubleLit 2.0)
              , (MkFieldName "lb", EListLit (Just EBool) [EBoolLit True, EBoolLit False])
              , (MkFieldName "st", (ETextLit (MkChunks [] "hello")))
-             , (MkFieldName "mst", (ETextLit (MkChunks [] "hello")))
+             , (MkFieldName "mst", ESome $ (ETextLit (MkChunks [] "hello")))
+             , (MkFieldName "mst2", ENone)
              ])
 
 data ExADT1

--- a/tests/derive/derive001/expected
+++ b/tests/derive/derive001/expected
@@ -1,4 +1,4 @@
-Just (MkExample3 Just 3 4 5 True 2.0 [True, False] "hello" Just "hello")
+Just (MkExample3 Just 3 4 5 True 2.0 [True, False] "hello" Just "hello" Nothing)
 Just Foo
 Just (Bar True)
 Just (Baz Just True)

--- a/tests/examples/example001/expected
+++ b/tests/examples/example001/expected
@@ -1,1 +1,1 @@
-Right MkPackage "myidrispackage" Nothing Nothing ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]
+Right MkPackage "myidrispackage" Just "./" Just ["contrib"] ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]


### PR DESCRIPTION
Was treating it like an optional json record, rather than a dhall field that must be of type Optional with a Some/None constructor

Eg. when deriving Idris type something like:
```
record Example where
  foo : Maybe Nat
  bar : Nat
```

before you could pass `{ foo = Some 3, bar = 3 }`, or `{ bar = 3 }` (and maybe also `{ foo = 3, bar = 3 }`).

Now you can only pass `{ foo = Some 3, bar = 3 }`, or `{ foo = None, bar = 3 }`.

Though you can still pass `{ foo = None, bar = 3, baz = 0 }` and the `baz`
field will be ignored.

cc @ohad