### PR TITLE
Fix derive `None`

### DIFF
--- a/Idrall/Derive.idr
+++ b/Idrall/Derive.idr
@@ -144,7 +144,7 @@ export
 FromDhall a => FromDhall (Maybe a) where
   fromDhall (ESome x) =
     pure $ fromDhall x
-  fromDhall ENone = pure $ neutral
+  fromDhall (EApp ENone _) = pure $ neutral
   fromDhall _ = neutral
 
 ||| Used with FromDhall interface, to dervice implementations

--- a/examples/Package.idr
+++ b/examples/Package.idr
@@ -9,13 +9,14 @@ record Package where
   constructor MkPackage
   package : String
   sourceDir : Maybe String
+  license : Maybe String
   depends : Maybe (List String)
   modules : List String
 %runElab (deriveFromDhall Record `{ Package })
 
 Show Package where
-  show (MkPackage package sourceDir depends modules) =
-    "MkPackage \{show package} \{show sourceDir} \{show depends} \{show modules}"
+  show (MkPackage package sourceDir license depends modules) =
+    "MkPackage \{show package} \{show sourceDir} \{show license} \{show depends} \{show modules}"
 
 main : IO ()
 main = do

--- a/examples/package.dhall
+++ b/examples/package.dhall
@@ -1,5 +1,6 @@
 { package = "myidrispackage"
 , sourceDir = Some "./"
+, license = None Text
 , depends = Some ["contrib"]
 , modules = ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]
 }

--- a/tests/derive/derive001/Derive.idr
+++ b/tests/derive/derive001/Derive.idr
@@ -43,7 +43,7 @@ exRec1 = fromDhall
              , (MkFieldName "lb", EListLit (Just EBool) [EBoolLit True, EBoolLit False])
              , (MkFieldName "st", (ETextLit (MkChunks [] "hello")))
              , (MkFieldName "mst", ESome $ (ETextLit (MkChunks [] "hello")))
-             , (MkFieldName "mst2", ENone)
+             , (MkFieldName "mst2", (EApp ENone EText))
              ])
 
 data ExADT1

--- a/tests/examples/example001/expected
+++ b/tests/examples/example001/expected
@@ -1,1 +1,1 @@
-Right MkPackage "myidrispackage" Just "./" Just ["contrib"] ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]
+Right MkPackage "myidrispackage" Just "./" Nothing Just ["contrib"] ["MyIdrisPackage.Main", "MyIdrisPackage.Foo"]


### PR DESCRIPTION
When trying to derive a type like `{ foo : Some Text }`, it was
incorrectly expecting a value like `{ foo = None }` instead of `{ foo =
None Text }`.