### PR TITLE
New parser - part 1

### DIFF
--- a/Idrall/Parser/Core.idr
+++ b/Idrall/Parser/Core.idr
@@ -1,0 +1,1 @@
+module Idrall.Parser.Core

--- a/Idrall/Parser/Core.idr
+++ b/Idrall/Parser/Core.idr
@@ -1,1 +1,0 @@
-module Idrall.Parser.Core

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -55,45 +55,6 @@ Show RawToken where
   show Unrecognised = "Unrecognised"
   show EndInput = "EndInput"
 
-{-
-public export
-TokenKind RawToken where
-  TokType (Ident _) = ()
-  TokType (Symbol _) = ()
-  TokType (Keyword _) = ()
-  TokType InterpBegin = ()
-  TokType InterpEnd = ()
-  TokType (StringLit _) = ()
-  TokType White = ()
-  TokType (Comment _) = ()
-  TokType Unrecognised = String
-  TokType EndInput = ()
-
-  tokValue (Ident _) _ = ()
-  tokValue (Symbol _) _ = ()
-  tokValue (Keyword _) _ = ()
-  tokValue InterpBegin _ = ()
-  tokValue InterpEnd _ = ()
-  tokValue (StringLit _) _ = ()
-  tokValue White _ = ()
-  tokValue (Comment _) _ = ()
-  tokValue Unrecognised x = x
-  tokValue EndInput _ = ()
-
-export
-Show (Token RawToken) where
-  show (Tok (Ident x) _) = "Ident \{show x}"
-  show (Tok (Symbol x) _) = "Symbol \{show x}"
-  show (Tok (Keyword x) _) = "Keyword \{show x}"
-  show (Tok InterpBegin _) = "InterpBegin"
-  show (Tok InterpEnd _) = "InterpEnd"
-  show (Tok (StringLit x) _) = "StringLit \{show x}"
-  show (Tok White _) = "White"
-  show (Tok (Comment x) _) = "Comment \{show x}"
-  show (Tok (Unrecognised) text) = "Unrecognised \{show $ Token.tokValue Unrecognised text}"
-  show (Tok EndInput _) = "EndInput"
-  -}
-
 public export
 TokenRawToken : Type
 TokenRawToken = RawToken

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -9,8 +9,6 @@ import Text.Token
 import Text.Lexer
 import Text.Bounded
 
-import Idrall.Parser.Core
-
 public export
 data RawToken
   = Ident

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -1,0 +1,127 @@
+module Idrall.Parser.Lexer
+
+import Data.List
+import Data.List1
+
+import Text.Parser
+import Text.Quantity
+import Text.Token
+import Text.Lexer
+import Text.Bounded
+
+import Idrall.Parser.Core
+
+public export
+data RawToken
+  = Ident
+  | Symbol String
+  | Keyword String
+  | White
+  | Unrecognised
+
+export
+Eq RawToken where
+  (==) Ident Ident = True
+  (==) (Symbol x) (Symbol y) = x == y
+  (==) (Keyword x) (Keyword y) = x == y
+  (==) White White = True
+  (==) Unrecognised Unrecognised = True
+  (==) _ _ = False
+
+export
+Show RawToken where
+  show (Ident) = "Ident"
+  show (Symbol x) = "Symbol \{show x}"
+  show (Keyword x) = "Keyword \{show x}"
+  show (White) = "White"
+  show (Unrecognised) = "Unrecognised"
+
+public export
+TokenKind RawToken where
+  TokType Ident = String
+  TokType (Symbol _) = ()
+  TokType (Keyword _) = ()
+  TokType White = ()
+  TokType Unrecognised = String
+
+  tokValue Ident x = x
+  tokValue (Symbol _) _ = ()
+  tokValue (Keyword _) _ = ()
+  tokValue White _ = ()
+  tokValue Unrecognised x = x
+
+export
+Show (Token RawToken) where
+  show (Tok Ident text) = "Ident \{show $ Token.tokValue Ident text}"
+  show (Tok (Symbol x) _) = "Symbol \{show $ x}"
+  show (Tok (Keyword x) _) = "Keyword \{show $ x}"
+  show (Tok White _) = "White"
+  show (Tok (Unrecognised) text) = "Unrecognised \{show $ Token.tokValue Unrecognised text}"
+
+public export
+TokenRawToken : Type
+TokenRawToken = Token RawToken
+
+isIdentStart : Char -> Bool
+isIdentStart '_' = True
+isIdentStart x  = isAlpha x || x > chr 160
+
+isIdentTrailing : Char -> Bool
+isIdentTrailing '_' = True
+isIdentTrailing '/' = True
+isIdentTrailing x = isAlphaNum x || x > chr 160
+
+export %inline
+isIdent : String -> Bool
+isIdent string =
+  case unpack string of
+    []      => False
+    (x::xs) => isIdentStart x && all (isIdentTrailing) xs
+
+ident : Lexer
+ident = do
+  (pred $ isIdentStart) <+> (many . pred $ isIdentTrailing)
+
+
+export
+builtins : List String
+builtins = ["True", "False"]
+
+export
+keywords : List String
+keywords = ["let", "in", "with"]
+
+parseIdent : String -> TokenRawToken
+parseIdent x =
+  let isKeyword = elem x keywords
+      isBuiltin = elem x builtins in
+  case (isKeyword, isBuiltin) of
+       (True, False) => Tok (Keyword x) x
+       (False, True) => Tok Ident x -- TODO Builtin
+       (_, _) => Tok Ident x
+
+rawTokenMap : TokenMap (TokenRawToken)
+rawTokenMap =
+   ((toTokenMap $
+    [ (exact "=", Symbol "=")
+    , (exact "&&", Symbol "&&")
+    , (exact "(", Symbol "(")
+    , (exact ")", Symbol ")")
+    , (exact "{", Symbol "{")
+    , (exact "}", Symbol "}")
+    , (exact "[", Symbol "[")
+    , (exact "]", Symbol "]")
+    , (exact ",", Symbol ",")
+    , (exact ".", Symbol ".")
+    , (space, White)
+    ]) ++ [(ident, (\x => parseIdent x))])
+    ++ (toTokenMap $ [ (any, Unrecognised) ])
+
+export
+lexRaw : String -> List (WithBounds TokenRawToken)
+lexRaw str =
+  let
+    (tokens, _, _, _) = lex rawTokenMap str -- those _ contain the source positions
+  in
+    -- map TokenData.tok tokens
+    tokens

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -18,6 +18,7 @@ data RawToken
   = Ident String
   | Symbol String
   | Keyword String
+  | Builtin String
   | TDouble Double
   | InterpBegin
   | InterpEnd
@@ -35,6 +36,7 @@ Eq RawToken where
   (==) (Ident x) (Ident y) = x == y
   (==) (Symbol x) (Symbol y) = x == y
   (==) (Keyword x) (Keyword y) = x == y
+  (==) (Builtin x) (Builtin y) = x == y
   (==) (TDouble x) (TDouble y) = x == y
   (==) InterpBegin InterpBegin = True
   (==) InterpEnd InterpEnd = True
@@ -53,6 +55,7 @@ Show RawToken where
   show (Ident x) = "Ident \{show x}"
   show (Symbol x) = "Symbol \{show x}"
   show (Keyword x) = "Keyword \{show x}"
+  show (Builtin x) = "Builtin \{show x}"
   show (TDouble x) = "TDouble \{show x}"
   show InterpBegin = "InterpBegin"
   show InterpEnd = "InterpEnd"
@@ -71,7 +74,17 @@ TokenRawToken = RawToken
 
 export
 builtins : List String
-builtins = ["True", "False"]
+builtins = ["True", "False",
+  "Natural/build", "Natural/fold", "Natural/isZero", "Natural/even",
+  "Natural/odd", "Natural/subtract", "Natural/toInteger", "Natural/show",
+  "Integer/show", "Integer/negate", "Integer/clamp", "Integer/toDouble",
+  "Double/show",
+  "List/build", "List/fold", "List/length", "List/head",
+  "List/last", "List/indexed", "List/reverse", "List",
+  "Text/show", "Text/replace",
+  "None",
+  "Optional",
+  "NaN"]
 
 export
 keywords : List String
@@ -95,8 +108,8 @@ parseIdent x =
   let isKeyword = elem x keywords
       isBuiltin = elem x builtins in
   case (isKeyword, isBuiltin) of
-       (True, False) => (Keyword x)
-       (False, True) => Ident x -- TODO Builtin
+       (True, False) => Keyword x
+       (False, True) => Builtin x
        (_, _) => Ident x
 
 -- double

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -8,6 +8,10 @@ import public Text.Lexer.Tokenizer
 
 public export
 data IsMultiline = Multi | Single
+Eq IsMultiline where
+  (==) Multi Multi = True
+  (==) Single Single = True
+  (==) _ _ = False
 
 public export
 data RawToken
@@ -32,7 +36,7 @@ Eq RawToken where
   (==) (Keyword x) (Keyword y) = x == y
   (==) InterpBegin InterpBegin = True
   (==) InterpEnd InterpEnd = True
-  (==) (StringBegin x) (StringBegin y) = ?kjkj
+  (==) (StringBegin x) (StringBegin y) = x == y
   (==) StringEnd StringEnd = True
   (==) (StringLit x) (StringLit y) = x == y
   (==) White White = True

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -103,6 +103,7 @@ rawTokenMap =
    ((toTokenMap $
     [ (exact "=", Symbol "=")
     , (exact "&&", Symbol "&&")
+    , (exact "->", Symbol "->")
     , (exact "(", Symbol "(")
     , (exact ")", Symbol ")")
     , (exact "{", Symbol "{")

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -106,3 +106,11 @@ dottedList = do
   -- x <- sepBy1 (match $ Symbol ".") (identPart)
   x <- sepBy1 (symbol ".") (identPart)
   pure x
+
+export
+builtin : Rule String
+builtin =
+  terminal "expected builtin" $
+    \case
+      Builtin x => Just x
+      _ => Nothing

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -1,0 +1,60 @@
+module Idrall.Parser.Rule
+
+import Data.List
+import Data.List1
+
+import Text.Parser
+import Text.Quantity
+import Text.Token
+import Text.Lexer
+import Text.Bounded
+
+import Idrall.Parser.Lexer
+
+public export
+Rule : {state : Type} -> Type -> Type
+Rule ty = Grammar state RawToken True ty
+
+public export
+EmptyRule : {state : Type} -> Type -> Type
+EmptyRule ty = Grammar state RawToken False ty
+
+export
+whitespace : Rule ()
+whitespace =
+  terminal ("Expected whitespace") $
+    \case
+      White => Just ()
+      _ => Nothing
+
+export
+keyword : String -> Rule ()
+keyword req =
+  terminal ("Expected '" ++ req ++ "'") $
+    \case
+      Keyword s => if s == req then Just () else Nothing
+      _ => Nothing
+
+export
+symbol : String -> Rule ()
+symbol req =
+  terminal ("Expected '" ++ req ++ "'") $
+    \case
+      Symbol s => if s == req then Just () else Nothing
+      _ => Nothing
+
+export
+identPart : Rule String
+identPart =
+  terminal "expected name" $
+    \case
+      Ident x => Just x
+      _ => Nothing
+
+export
+dottedList : Rule (List1 String)
+dottedList = do
+  -- x <- sepBy1 (match $ Symbol ".") (identPart)
+  x <- sepBy1 (symbol ".") (identPart)
+  pure x
+

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -44,6 +44,39 @@ symbol req =
       _ => Nothing
 
 export
+textBoundary : Rule ()
+textBoundary =
+  terminal "expected \" or ''" $
+    \case
+      StringBegin _ => Just ()
+      StringEnd => Just ()
+      _ => Nothing
+
+export
+textLit : Rule String
+textLit =
+  terminal "expected valid Text" $
+    \case
+      StringLit x => Just x
+      _ => Nothing
+
+export
+interpBegin : Rule ()
+interpBegin =
+  terminal "expected ${" $
+    \case
+      InterpBegin => Just ()
+      _ => Nothing
+
+export
+interpEnd : Rule ()
+interpEnd =
+  terminal "expected }" $
+    \case
+      InterpEnd => Just ()
+      _ => Nothing
+
+export
 identPart : Rule String
 identPart =
   terminal "expected name" $

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -93,6 +93,14 @@ embedPath =
       _ => Nothing
 
 export
+doubleLit : Rule Double
+doubleLit =
+  terminal "expected double" $
+    \case
+      TDouble x => Just x
+      _ => Nothing
+
+export
 dottedList : Rule (List1 String)
 dottedList = do
   -- x <- sepBy1 (match $ Symbol ".") (identPart)

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -85,9 +85,16 @@ identPart =
       _ => Nothing
 
 export
+embedPath : Rule String
+embedPath =
+  terminal "expected import path" $
+    \case
+      FilePath x => Just x
+      _ => Nothing
+
+export
 dottedList : Rule (List1 String)
 dottedList = do
   -- x <- sepBy1 (match $ Symbol ".") (identPart)
   x <- sepBy1 (symbol ".") (identPart)
   pure x
-

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -117,11 +117,11 @@ chainl1 p op = do
   x <- p
   rest x
 where
-  rest : a -> Grammar (Token RawTokenKind) True (a)
-  rest a1 = do
+  rest : a -> Grammar (Token RawTokenKind) False (a)
+  rest a1 = (do
     f <- op
     a2 <- p
-    rest (f a1 a2) <|> pure a1
+    rest (f a1 a2)) <|> pure a1
 
 infixOp : Grammar (Token RawTokenKind) True ()
         -> (a -> a -> a)

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -315,3 +315,9 @@ doParse input = do
     x: \{show x}
     pretty: \{show doc}
     """
+
+normalString : String
+normalString = "\"foo\""
+
+interpString : String
+interpString = "\"fo ${True && \"ba ${False} r\"} o\""

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -284,9 +284,18 @@ Show (ParsingError (TokenRawToken)) where
     tokens: \{show xs}
     """
 
+removeComments : List (WithBounds TokenRawToken) -> List (WithBounds TokenRawToken)
+removeComments xs = filter pred xs
+where
+  pred : WithBounds TokenRawToken -> Bool
+  pred bounds = let tok = kind $ val bounds in
+    case tok of
+         Comment => False
+         _ => True
+
 doParse : String -> IO ()
 doParse input = do
-  let tokens = lexRaw input
+  let tokens = removeComments $ lexRaw input
   putStrLn $ "tokens: " ++ show tokens
 
   Right (expr, x) <- pure $ parse exprTerm tokens -- TODO use finalParser

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -162,6 +162,13 @@ tokenW p = do
   _ <- optional $ match $ White
   pure x
 
+anyIdent : Grammar state (RawToken) True RawToken
+anyIdent =
+  terminal "expected identity" $
+    \case
+      Ident => Just Ident
+      _ => Nothing
+
 mutual
   dottedList : Grammar state (TokenRawToken) True (List1 String)
   dottedList = do

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -74,39 +74,117 @@ mutual
     | EBoolLit FC Bool
     | EBoolAnd FC (Expr a) (Expr a)
     | ELet FC String (Expr a) (Expr a)
-    | EList FC (List (Expr a))
+    | EListLit FC (List (Expr a))
     | EWith FC (Expr a) (List1 String) (Expr a)
     | ETextLit FC (Chunks a)
+    | ENaturalBuild FC
+    | ENaturalFold FC
+    | ENaturalIsZero FC
+    | ENaturalEven FC
+    | ENaturalOdd FC
+    | ENaturalSubtract FC
+    | ENaturalToInteger FC
+    | ENaturalShow FC
+    | EIntegerShow FC
+    | EIntegerNegate FC
+    | EIntegerClamp FC
+    | EIntegerToDouble FC
+    | EDoubleShow FC
+    | EListBuild FC
+    | EListFold FC
+    | EListLength FC
+    | EListHead FC
+    | EListLast FC
+    | EListIndexed FC
+    | EListReverse FC
+    | EList FC
+    | ETextShow FC
+    | ETextReplace FC
+    | ENone FC
+    | EOptional FC
     | EEmbed FC String
 
 mkExprFC : OriginDesc -> WithBounds x -> (FC -> x -> Expr a) -> Expr a
 mkExprFC od e mkE = mkE (boundToFC od e) (val e)
 
+mkExprFC0 : OriginDesc -> WithBounds x -> (FC -> Expr a) -> Expr a
+mkExprFC0 od e mkE = mkE (boundToFC od e)
+
 getBounds : Expr a -> FC
-getBounds (EVar x _) = x
-getBounds (EApp x _ _) = x
-getBounds (EPi x _ _ _) = x
-getBounds (EDoubleLit x _) = x
-getBounds (EBoolLit x _) = x
-getBounds (EBoolAnd x _ _) = x
-getBounds (ELet x _ _ _) = x
-getBounds (EList x _) = x
-getBounds (EWith x _ _ _) = x
-getBounds (ETextLit x _) = x
-getBounds (EEmbed x _) = x
+getBounds (EVar fc _) = fc
+getBounds (EApp fc _ _) = fc
+getBounds (EPi fc _ _ _) = fc
+getBounds (EDoubleLit fc _) = fc
+getBounds (EBoolLit fc _) = fc
+getBounds (EBoolAnd fc _ _) = fc
+getBounds (ELet fc _ _ _) = fc
+getBounds (EListLit fc _) = fc
+getBounds (EWith fc _ _ _) = fc
+getBounds (ETextLit fc _) = fc
+getBounds (ENaturalBuild fc) = fc
+getBounds (ENaturalFold fc) = fc
+getBounds (ENaturalIsZero fc) = fc
+getBounds (ENaturalEven fc) = fc
+getBounds (ENaturalOdd fc) = fc
+getBounds (ENaturalSubtract fc) = fc
+getBounds (ENaturalToInteger fc) = fc
+getBounds (ENaturalShow fc) = fc
+getBounds (EIntegerShow fc) = fc
+getBounds (EIntegerNegate fc) = fc
+getBounds (EIntegerClamp fc) = fc
+getBounds (EIntegerToDouble fc) = fc
+getBounds (EDoubleShow fc) = fc
+getBounds (EListBuild fc) = fc
+getBounds (EListFold fc) = fc
+getBounds (EListLength fc) = fc
+getBounds (EListHead fc) = fc
+getBounds (EListLast fc) = fc
+getBounds (EListIndexed fc) = fc
+getBounds (EListReverse fc) = fc
+getBounds (EList fc) = fc
+getBounds (ETextShow fc) = fc
+getBounds (ETextReplace fc) = fc
+getBounds (ENone fc) = fc
+getBounds (EOptional fc) = fc
+getBounds (EEmbed fc _) = fc
 
 updateBounds : FC -> Expr a -> Expr a
-updateBounds x (EVar _ z) = EVar x z
-updateBounds x (EApp _ z w) = EApp x z w
-updateBounds x (EPi _ n z w) = EPi x n z w
-updateBounds x (EDoubleLit _ z) = EDoubleLit x z
-updateBounds x (EBoolLit _ z) = EBoolLit x z
-updateBounds x (EBoolAnd _ z w) = EBoolAnd x z w
-updateBounds x (ELet _ z w v) = ELet x z w v
-updateBounds x (EList _ z) = EList x z
-updateBounds x (EWith _ z s y) = EWith x z s y
-updateBounds x (ETextLit _ z) = ETextLit x z
-updateBounds x (EEmbed _ z) = EEmbed x z
+updateBounds fc (EVar _ z) = EVar fc z
+updateBounds fc (EApp _ z w) = EApp fc z w
+updateBounds fc (EPi _ n z w) = EPi fc n z w
+updateBounds fc (EDoubleLit _ z) = EDoubleLit fc z
+updateBounds fc (EBoolLit _ z) = EBoolLit fc z
+updateBounds fc (EBoolAnd _ z w) = EBoolAnd fc z w
+updateBounds fc (ELet _ z w v) = ELet fc z w v
+updateBounds fc (EListLit _ z) = EListLit fc z
+updateBounds fc (EWith _ z s y) = EWith fc z s y
+updateBounds fc (ETextLit _ z) = ETextLit fc z
+updateBounds fc (ENaturalBuild _) = ENaturalBuild fc
+updateBounds fc (ENaturalFold _) = ENaturalFold fc
+updateBounds fc (ENaturalIsZero _) = ENaturalIsZero fc
+updateBounds fc (ENaturalEven _) = ENaturalEven fc
+updateBounds fc (ENaturalOdd _) = ENaturalOdd fc
+updateBounds fc (ENaturalSubtract _) = ENaturalSubtract fc
+updateBounds fc (ENaturalToInteger _) = ENaturalToInteger fc
+updateBounds fc (ENaturalShow _) = ENaturalShow fc
+updateBounds fc (EIntegerShow _) = EIntegerShow fc
+updateBounds fc (EIntegerNegate _) = EIntegerNegate fc
+updateBounds fc (EIntegerClamp _) = EIntegerClamp fc
+updateBounds fc (EIntegerToDouble _) = EIntegerToDouble fc
+updateBounds fc (EDoubleShow _) = EDoubleShow fc
+updateBounds fc (EListBuild _) = EListBuild fc
+updateBounds fc (EListFold _) = EListFold fc
+updateBounds fc (EListLength _) = EListLength fc
+updateBounds fc (EListHead _) = EListHead fc
+updateBounds fc (EListLast _) = EListLast fc
+updateBounds fc (EListIndexed _) = EListIndexed fc
+updateBounds fc (EListReverse _) = EListReverse fc
+updateBounds fc (EList _) = EList fc
+updateBounds fc (ETextShow _) = ETextShow fc
+updateBounds fc (ETextReplace _) = ETextReplace fc
+updateBounds fc (ENone _) = ENone fc
+updateBounds fc (EOptional _) = EOptional fc
+updateBounds fc (EEmbed _ z) = EEmbed fc z
 
 public export
 Semigroup (Chunks a) where
@@ -130,10 +208,35 @@ mutual
     show (EBoolLit fc x) = "\{show fc}:EBoolLit \{show x}"
     show (EBoolAnd fc x y) = "(\{show fc}:EBoolAnd \{show x} \{show y})"
     show (ELet fc x y z) = "(\{show fc}:ELet \{show fc} \{show x} \{show y} \{show z})"
-    show (EList fc x) = "(\{show fc}:EList \{show fc} \{show x})"
+    show (EListLit fc x) = "(\{show fc}:EListLit \{show fc} \{show x})"
     show (EWith fc x s y) = "(\{show fc}:EWith \{show fc} \{show x} \{show s} \{show y})"
     show (ETextLit fc cs) = "(\{show fc}:ETextLit \{show fc} \{show cs}"
-    show (EEmbed fc x) = "(\{show fc}:EEmbed \{show fc} \{show x}"
+    show (ENaturalBuild fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalFold fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalIsZero fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalEven fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalOdd fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalSubtract fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalToInteger fc) = "(\{show fc}:ENaturalShow)"
+    show (ENaturalShow fc) = "(\{show fc}:ENaturalShow)"
+    show (EIntegerShow fc) = "(\{show fc}:EIntegerShow)"
+    show (EIntegerNegate fc) = "(\{show fc}:EIntegerShow)"
+    show (EIntegerClamp fc) = "(\{show fc}:EIntegerShow)"
+    show (EIntegerToDouble fc) = "(\{show fc}:EIntegerShow)"
+    show (EDoubleShow fc) = "(\{show fc}:EDoubleShow)"
+    show (EListBuild fc) = "(\{show fc}:EListBuild)"
+    show (EListFold fc) = "(\{show fc}:EListFold)"
+    show (EListLength fc) = "(\{show fc}:EListLength)"
+    show (EListHead fc) = "(\{show fc}:EListHead)"
+    show (EListLast fc) = "(\{show fc}:EListLast)"
+    show (EListIndexed fc) = "(\{show fc}:EListIndexed)"
+    show (EListReverse fc) = "(\{show fc}:EListReverse)"
+    show (EList fc) = "(\{show fc}:EList)"
+    show (ETextShow fc) = "(\{show fc}:ETextShow)"
+    show (ETextReplace fc) = "(\{show fc}:ETextReplace)"
+    show (ENone fc) = "(\{show fc}:ENone)"
+    show (EOptional fc) = "(\{show fc}:EOptional)"
+    show (EEmbed fc x) = "(\{show fc}:EEmbed \{show fc} \{show x})"
 
 prettyDottedList : List String -> Doc ann
 prettyDottedList [] = pretty ""
@@ -155,11 +258,36 @@ mutual
     pretty (EBoolLit fc x) = pretty $ show x
     pretty (EBoolAnd fc x y) = pretty x <++> pretty "&&" <++> pretty y
     pretty (ELet fc x y z) = pretty "let" <+> pretty x <+> pretty y <+> pretty z
-    pretty (EList fc xs) = pretty xs
+    pretty (EListLit fc xs) = pretty xs
     pretty (EWith fc x xs y) =
       pretty x <++> pretty "with" <++>
       prettyDottedList (forget xs) <++> pretty "=" <++> pretty y
     pretty (ETextLit fc cs) = pretty cs
+    pretty (ENaturalBuild fc) = pretty "Natural/build"
+    pretty (ENaturalFold fc) = pretty "Natural/fold"
+    pretty (ENaturalIsZero fc) = pretty "Natural/isZero"
+    pretty (ENaturalEven fc) = pretty "Natural/Even"
+    pretty (ENaturalOdd fc) = pretty "Natural/Odd"
+    pretty (ENaturalSubtract fc) = pretty "Natural/subtract"
+    pretty (ENaturalToInteger fc) = pretty "Natural/toInteger"
+    pretty (ENaturalShow fc) = pretty "Natural/show"
+    pretty (EIntegerShow fc) = pretty "Integer/show"
+    pretty (EIntegerNegate fc) = pretty "Integer/negate"
+    pretty (EIntegerClamp fc) = pretty "Integer/clamp"
+    pretty (EIntegerToDouble fc) = pretty "Integer/toDouble"
+    pretty (EDoubleShow fc) = pretty "Double/show"
+    pretty (EListBuild fc) = pretty "List/build"
+    pretty (EListFold fc) = pretty "List/fold"
+    pretty (EListLength fc) = pretty "List/length"
+    pretty (EListHead fc) = pretty "List/head"
+    pretty (EListLast fc) = pretty "List/last"
+    pretty (EListIndexed fc) = pretty "List/indexed"
+    pretty (EListReverse fc) = pretty "List/indexed"
+    pretty (EList fc) = pretty "List"
+    pretty (ETextShow fc) = pretty "Text/show"
+    pretty (ETextReplace fc) = pretty "Text/replace"
+    pretty (ENone fc) = pretty "None"
+    pretty (EOptional fc) = pretty "Optional"
     pretty (EEmbed fc x) = pretty x
 
 public export
@@ -216,10 +344,41 @@ tokenW p = do
   _ <- optional whitespace
   pure x
 
-mutual
-  builtinTerm : WithBounds String -> Grammar state (TokenRawToken) False (Expr ())
-  builtinTerm _ = fail "TODO not implemented"
+builtinTerm : WithBounds String -> Grammar state (TokenRawToken) False (Expr ())
+builtinTerm str =
+  case val str of
+     "Natural/build" => pure $ cons ENaturalBuild
+     "Natural/fold" => pure $ cons ENaturalFold
+     "Natural/isZero" => pure $ cons ENaturalIsZero
+     "Natural/even" => pure $ cons ENaturalEven
+     "Natural/odd" => pure $ cons ENaturalOdd
+     "Natural/subtract" => pure $ cons ENaturalSubtract
+     "Natural/toInteger" => pure $ cons ENaturalToInteger
+     "Natural/show" => pure $ cons ENaturalShow
+     "Integer/show" => pure $ cons EIntegerShow
+     "Integer/negate" => pure $ cons EIntegerNegate
+     "Integer/clamp" => pure $ cons EIntegerClamp
+     "Integer/toDouble" => pure $ cons EIntegerToDouble
+     "Double/show" => pure $ cons EDoubleShow
+     "List/build" => pure $ cons EListBuild
+     "List/fold" => pure $ cons EListFold
+     "List/length" => pure $ cons EListLength
+     "List/head" => pure $ cons EListHead
+     "List/last" => pure $ cons EListLast
+     "List/indexed" => pure $ cons EListIndexed
+     "List/reverse" => pure $ cons EListReverse
+     "List" => pure $ cons EList
+     "Text/show" => pure $ cons ETextShow
+     "Text/replace" => pure $ cons ETextReplace
+     "None" => pure $ cons ENone
+     "Optional" => pure $ cons EOptional
+     "NaN" => pure $ EDoubleLit (boundToFC initBounds str) (0.0/0.0)
+     x => fail "Expected builtin name"
+  where
+    cons : (FC -> Expr ()) -> Expr ()
+    cons = mkExprFC0 initBounds str
 
+mutual
   embed : Grammar state (TokenRawToken) True (Expr ())
   embed = do
     s <- bounds $ embedPath
@@ -252,10 +411,15 @@ mutual
   boolLit b@(MkBounded "False" isIrrelevant bounds) = pure $ EBoolLit (boundToFC initBounds b) False
   boolLit (MkBounded _ isIrrelevant bounds) = fail "unrecognised const"
 
+  builtin : Grammar state (TokenRawToken) True (Expr ())
+  builtin = do
+      name <- bounds $ Rule.builtin
+      builtinTerm name
+
   varTerm : Grammar state (TokenRawToken) True (Expr ())
   varTerm = do
       name <- bounds $ identPart
-      builtinTerm name <|> boolLit name <|> toVar (isKeyword name)
+      boolLit name <|> toVar (isKeyword name)
   where
     isKeyword : WithBounds String -> Maybe $ Expr ()
     isKeyword b@(MkBounded val isIrrelevant bounds) =
@@ -282,7 +446,7 @@ mutual
   atom = do
     a <- varTerm <|> textLit
       <|> doubleLit
-      <|> embed
+      <|> builtin <|> embed
       <|> listExpr <|> (between (symbol "(") (symbol ")") exprTerm)
     pure a
 
@@ -293,13 +457,13 @@ mutual
     emptyList = do
       start <- bounds $ symbol "["
       end <- bounds $ symbol "]"
-      pure $ EList (mergeBounds (boundToFC initBounds start) (boundToFC initBounds end)) []
+      pure $ EListLit (mergeBounds (boundToFC initBounds start) (boundToFC initBounds end)) []
     populatedList : Grammar state (TokenRawToken) True (Expr ())
     populatedList = do
       start <- bounds $ symbol "["
       es <- sepBy1 (symbol ",") exprTerm
       end <- bounds $ symbol "]"
-      pure $ EList (mergeBounds (boundToFC initBounds start) (boundToFC initBounds end)) (forget es)
+      pure $ EListLit (mergeBounds (boundToFC initBounds start) (boundToFC initBounds end)) (forget es)
 
   boolOp : FC -> Grammar state (TokenRawToken) True (Expr () -> Expr () -> Expr ())
   boolOp fc =

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -1,0 +1,184 @@
+module Idrall.ParserNew
+
+import Data.List
+
+import Text.Parser
+import Text.Quantity
+import Text.Token
+import Text.Lexer
+
+data RawTokenKind
+  = Ident
+  | Symbol String
+  | White
+  | Unrecognised
+
+Eq RawTokenKind where
+  (==) Ident Ident = True
+  (==) (Symbol x) (Symbol y) = x == y
+  (==) White White = True
+  (==) Unrecognised Unrecognised = True
+  (==) _ _ = False
+
+Show RawTokenKind where
+  show (Ident) = "Ident"
+  show (Symbol x) = "Symbol \{show x}"
+  show (White) = "White"
+  show (Unrecognised) = "Unrecognised"
+
+TokenKind RawTokenKind where
+  TokType Ident = String
+  TokType (Symbol _) = ()
+  TokType White = ()
+  TokType Unrecognised = String
+
+  tokValue Ident x = x
+  tokValue (Symbol _) _ = ()
+  tokValue White _ = ()
+  tokValue Unrecognised x = x
+
+Show (Token RawTokenKind) where
+  show (Tok Ident text) = "Ident \{show $ Token.tokValue Ident text}"
+  show (Tok (Symbol x) _) = "Symbol \{show $ x}"
+  show (Tok White _) = "White"
+  show (Tok (Unrecognised) text) = "Unrecognised \{show $ Token.tokValue Unrecognised text}"
+
+isIdentStart : Char -> Bool
+isIdentStart '_' = True
+isIdentStart x  = isAlpha x || x > chr 160
+
+isIdentTrailing : Char -> Bool
+isIdentTrailing '_' = True
+isIdentTrailing '/' = True
+isIdentTrailing x = isAlphaNum x || x > chr 160
+
+export %inline
+isIdent : String -> Bool
+isIdent string =
+  case unpack string of
+    []      => False
+    (x::xs) => isIdentStart x && all (isIdentTrailing) xs
+
+ident : Lexer
+ident = do
+  (pred $ isIdentStart) <+> (many . pred $ isIdentTrailing)
+
+
+builtins : List String
+builtins = ["True", "False"]
+
+keywords : List String
+keywords = ["let", "in"]
+
+parseIdent : String -> Token RawTokenKind
+parseIdent x =
+  let isKeyword = elem x keywords
+      isBuiltin = elem x builtins in
+  case (isKeyword, isBuiltin) of
+       (True, False) => Tok Ident x -- TODO keyword
+       (False, True) => Tok Ident x -- TODO Builtin
+       (_, _) => Tok Ident x
+
+rawTokenMap : TokenMap (Token RawTokenKind)
+rawTokenMap =
+   ((toTokenMap $
+    [ (exact "=", Symbol "=")
+    , (exact "&&", Symbol "&&")
+    , (exact "(", Symbol "(")
+    , (exact ")", Symbol ")")
+    , (space, White)
+    ]) ++ [(ident, (\x => parseIdent x))])
+    ++ (toTokenMap $ [ (any, Unrecognised) ])
+
+lexRaw : String -> List (Token RawTokenKind)
+lexRaw str =
+  let
+    (tokens, _, _, _) = lex rawTokenMap str -- those _ contain the source positions
+  in
+    map TokenData.tok tokens
+
+||| Raw AST representation generated directly from the parser
+data Expr a
+  = EVar String
+  | EBoolLit Bool
+  | EBoolAnd (Expr a) (Expr a)
+  | ELet String (Expr a) (Expr a)
+
+Show (Expr a) where
+  show (EVar x) = "EVar \{show x}"
+  show (EBoolLit x) = "EBoolLit \{show x}"
+  show (EBoolAnd x y) = "(EBoolAnd \{show x} \{show y})"
+  show (ELet x y z) = "TODO"
+
+chainl1 : Grammar (Token RawTokenKind) True (a)
+       -> Grammar (Token RawTokenKind) True (a -> a -> a)
+       -> Grammar (Token RawTokenKind) True (a)
+chainl1 p op = do
+  x <- p
+  rest x
+where
+  rest : a -> Grammar (Token RawTokenKind) True (a)
+  rest a1 = do
+    f <- op
+    a2 <- p
+    rest (f a1 a2) <|> pure a1
+
+infixOp : Grammar (Token RawTokenKind) True ()
+        -> (a -> a -> a)
+        -> Grammar (Token RawTokenKind) True (a -> a -> a)
+infixOp l ctor = do
+  l
+  Text.Parser.Core.pure ctor
+
+mutual
+  builtinTerm : String -> Grammar (Token RawTokenKind) False (Expr ())
+  builtinTerm _ = fail "TODO not implemented"
+
+  boolTerm : String -> Grammar (Token RawTokenKind) False (Expr ())
+  boolTerm "True" = pure $ EBoolLit True
+  boolTerm "False" = pure $ EBoolLit False
+  boolTerm _ = fail "unrecognised const"
+
+  varTerm : Grammar (Token RawTokenKind) True (Expr ())
+  varTerm = do
+      name <- match Ident
+      builtinTerm name <|> boolTerm name <|> toVar (isKeyword name)
+  where
+    isKeyword : String -> Maybe $ Expr ()
+    isKeyword x =
+      let isKeyword = elem x keywords
+      in case (isKeyword) of
+              (True) => Nothing
+              (False) => pure $ EVar x
+    toVar : Maybe $ Expr () -> Grammar (Token RawTokenKind) False (Expr ())
+    toVar Nothing = fail "is reserved word"
+    toVar (Just x) = pure x
+
+  atom : Grammar (Token RawTokenKind) True (Expr ())
+  atom = varTerm <|> (between (match $ Symbol "(") (match $ Symbol ")") exprTerm)
+
+  boolOp : Grammar (Token RawTokenKind) True (Expr () -> Expr () -> Expr ())
+  boolOp = infixOp (match $ Symbol "&&") EBoolAnd
+
+  exprTerm : Grammar (Token RawTokenKind) True (Expr ())
+  exprTerm = chainl1 atom boolOp
+
+Show (ParseError (Token RawTokenKind)) where
+  show (Error x xs) =
+    """
+    error: \{x}
+    tokens: \{show xs}
+    """
+
+doParse : String -> IO ()
+doParse input = do
+  let tokens = lexRaw input
+  putStrLn $ "tokens: " ++ show tokens
+
+  Right (rawTerms, x) <- pure $ parse exprTerm tokens
+    | Left e => printLn $ show e
+  putStrLn $
+    """
+    rawTerms: \{show rawTerms}
+    x: \{show x}
+    """

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -67,42 +67,75 @@ mutual
 
   ||| Raw AST representation generated directly from the parser
   data Expr a
-    = EVar FC String
-    | EApp FC (Expr a) (Expr a)
-    | EPi FC String (Expr a) (Expr a)
-    | EDoubleLit FC Double
-    | EBoolLit FC Bool
-    | EBoolAnd FC (Expr a) (Expr a)
-    | ELet FC String (Expr a) (Expr a)
-    | EListLit FC (List (Expr a))
-    | EWith FC (Expr a) (List1 String) (Expr a)
-    | ETextLit FC (Chunks a)
-    | ENaturalBuild FC
-    | ENaturalFold FC
-    | ENaturalIsZero FC
-    | ENaturalEven FC
-    | ENaturalOdd FC
-    | ENaturalSubtract FC
-    | ENaturalToInteger FC
-    | ENaturalShow FC
-    | EIntegerShow FC
-    | EIntegerNegate FC
-    | EIntegerClamp FC
-    | EIntegerToDouble FC
-    | EDoubleShow FC
-    | EListBuild FC
-    | EListFold FC
-    | EListLength FC
-    | EListHead FC
-    | EListLast FC
-    | EListIndexed FC
-    | EListReverse FC
-    | EList FC
-    | ETextShow FC
-    | ETextReplace FC
-    | ENone FC
-    | EOptional FC
-    | EEmbed FC String
+    -- = EConst U
+    = EVar FC String -- | EVar Name Int
+    -- | ELam Name (Expr a) (Expr a)
+    | EPi FC String (Expr a) (Expr a) -- | EPi Name (Expr a) (Expr a)
+    | EApp FC (Expr a) (Expr a) -- | EApp (Expr a) (Expr a)
+    | ELet FC String (Expr a) (Expr a) -- | ELet Name (Maybe (Expr a)) (Expr a) (Expr a)
+    -- | EAnnot (Expr a) (Expr a)
+    -- | EBool
+    | EBoolLit FC Bool -- | EBoolLit Bool
+    | EBoolAnd FC (Expr a) (Expr a) -- | EBoolAnd (Expr a) (Expr a)
+    -- | EBoolOr  (Expr a) (Expr a)
+    -- | EBoolEQ  (Expr a) (Expr a)
+    -- | EBoolNE  (Expr a) (Expr a)
+    -- | EBoolIf (Expr a) (Expr a) (Expr a)
+    -- | ENatural
+    -- | ENaturalLit Nat
+    | ENaturalFold FC -- | ENaturalFold
+    | ENaturalBuild FC -- | ENaturalBuild
+    | ENaturalIsZero FC -- | ENaturalIsZero
+    | ENaturalEven FC -- | ENaturalEven
+    | ENaturalOdd FC -- | ENaturalOdd
+    | ENaturalToInteger FC -- | ENaturalToInteger
+    | ENaturalSubtract FC -- | ENaturalSubtract
+    | ENaturalShow FC -- | ENaturalShow
+    -- | ENaturalPlus (Expr a) (Expr a)
+    -- | ENaturalTimes (Expr a) (Expr a)
+    -- | EInteger
+    -- | EIntegerLit Integer
+    | EIntegerShow FC -- | EIntegerShow
+    | EIntegerClamp FC -- | EIntegerClamp
+    | EIntegerNegate FC -- | EIntegerNegate
+    | EIntegerToDouble FC -- | EIntegerToDouble
+    -- | EDouble
+    | EDoubleLit FC Double -- | EDoubleLit Double
+    | EDoubleShow FC -- | EDoubleShow
+    -- | EText
+    | ETextLit FC (Chunks a) -- | ETextLit (Chunks a)
+    -- | ETextAppend (Expr a) (Expr a)
+    | ETextShow FC -- | ETextShow
+    | ETextReplace FC -- | ETextReplace
+    | EList FC -- | EList
+    | EListLit FC (List (Expr a)) -- | EListLit (Maybe (Expr a)) (List (Expr a))
+    -- | EListAppend (Expr a) (Expr a)
+    | EListBuild FC -- | EListBuild
+    | EListFold FC -- | EListFold
+    | EListLength FC -- | EListLength
+    | EListHead FC -- | EListHead
+    | EListLast FC -- | EListLast
+    | EListIndexed FC -- | EListIndexed
+    | EListReverse FC -- | EListReverse
+    | EOptional FC -- | EOptional
+    | ENone FC -- | ENone
+    -- | ESome (Expr a)
+    -- | EEquivalent (Expr a) (Expr a)
+    -- | EAssert (Expr a)
+    -- | ERecord (SortedMap FieldName (Expr a))
+    -- | ERecordLit (SortedMap FieldName (Expr a))
+    -- | EUnion (SortedMap FieldName (Maybe (Expr a)))
+    -- | ECombine (Expr a) (Expr a)
+    -- | ECombineTypes (Expr a) (Expr a)
+    -- | EPrefer (Expr a) (Expr a)
+    -- | ERecordCompletion (Expr a) (Expr a)
+    -- | EMerge (Expr a) (Expr a) (Maybe (Expr a))
+    -- | EToMap (Expr a) (Maybe (Expr a))
+    -- | EField (Expr a) FieldName
+    -- | EProject (Expr a) (Either (List FieldName) (Expr a))
+    | EWith FC (Expr a) (List1 String) (Expr a) -- | EWith (Expr a) (List1 FieldName) (Expr a)
+    -- | EImportAlt (Expr a) (Expr a)
+    | EEmbed FC String -- | EEmbed (Import a)
 
 mkExprFC : OriginDesc -> WithBounds x -> (FC -> x -> Expr a) -> Expr a
 mkExprFC od e mkE = mkE (boundToFC od e) (val e)

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -187,7 +187,7 @@ mutual
       in case (isKeyword) of
               (True) => Nothing
               (False) => pure $ EVar (boundToFC Nothing b) val
-    toVar : Maybe $ Expr () -> Grammar state (TokenRawToken) False (Expr ())
+    toVar : Maybe (Expr ()) -> Grammar state (TokenRawToken) False (Expr ())
     toVar Nothing = fail "is reserved word"
     toVar (Just x) = pure x
 
@@ -276,10 +276,6 @@ finalParser = do
   e <- exprTerm
   eof
   pure e
-
-Show (Bounds) where
-  show (MkBounds startLine startCol endLine endCol) =
-    "sl:\{show startLine} sc:\{show startCol} el:\{show endLine} ec:\{show endCol}"
 
 Show (ParsingError (TokenRawToken)) where
   show (Error x xs) =

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ demo: test-setup
 repl: test-setup
 	rlwrap -n idris2 -p contrib Idrall/APIv1.idr
 
+repl2: test-setup
+	rlwrap -n idris2 -p contrib Idrall/ParserNew.idr
+
 edit-tests: test-setup
 	cd ./tests/idrall/idrall002 && rlwrap -n idris2 -p contrib -p test -p idrall All.idr
 

--- a/idrall.ipkg
+++ b/idrall.ipkg
@@ -7,6 +7,7 @@ modules = Idrall.Expr
         , Idrall.Value
         , Idrall.Resolve
         , Idrall.Parser
+        , Idrall.ParserNew
         , Idrall.Lexer
         , Idrall.Eval
         , Idrall.Check


### PR DESCRIPTION
Part 1 of migrating away from `Data.String.Parser` to `Text.Parser`. This is enable source location info for error messages. It will also align a bit closer with idris2's internal parser, which should help for maintenance. 

This isn't in use yet, but I thought I'd get it in master and iterate on it from there.