### PR TITLE
New parser prep, part2 [possibly breaking]

### DIFF
--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -25,7 +25,7 @@ freshCl cl@(MkClosure x _ _) env = (x, snd (fresh x env), cl)
 
 mutual
   qVar : Name -> Int -> List Name -> Expr Void
-  qVar x i env = EVar x ((countName' x env) - i - 1)
+  qVar x i env = EVar initFC x ((countName' x env) - i - 1)
 
   quoteBind : Name -> List Name -> Value -> Either Error (Expr Void)
   quoteBind x env = quote (x :: env)
@@ -40,106 +40,106 @@ mutual
 
   export
   quote : List Name -> Value -> Either Error (Expr Void)
-  quote env (VConst k) = Right $ EConst k
-  quote env (VVar x i) = Right $ qVar x i env
-  quote env (VApp t u) = qApp env !(quote env t) u
-  quote env (VLambda a b) =
+  quote env (VConst fc k) = Right $ EConst k
+  quote env (VVar fc x i) = Right $ qVar x i env
+  quote env (VApp fc t u) = qApp env !(quote env t) u
+  quote env (VLambda fc a b) =
     let (x, v, t) = freshCl b env in
         Right $ ELam x !(quote env a) !(quoteBind x env !(inst t v))
-  quote env (VHLam (Typed x a) t) =
+  quote env (VHLam fc (Typed x a) t) =
     let (x', v) = fresh x env in
     Right $ ELam x' !(quote env a) !(quoteBind x env !(t v))
-  quote env (VHLam NaturalSubtractZero _) =
+  quote env (VHLam fc NaturalSubtractZero _) =
     pure $ EApp ENaturalSubtract (ENaturalLit 0)
-  quote env (VHLam _ t) = quote env !(t VPrimVar)
-  quote env (VPi a b) =
+  quote env (VHLam fc _ t) = quote env !(t VPrimVar)
+  quote env (VPi fc a b) =
     let (x, v, b') = freshCl b env in
         Right $ EPi x !(quote env a) !(quoteBind x env !(inst b' v))
-  quote env (VHPi x a b) =
+  quote env (VHPi fc x a b) =
     let (x', v) = fresh x env in
         Right $ EPi x !(quote env a) !(quoteBind x env !(b v))
-  quote env VBool = pure $ EBool
-  quote env (VBoolLit b) = pure $ EBoolLit b
-  quote env (VBoolAnd t u) = pure $ EBoolAnd !(quote env t) !(quote env u)
-  quote env (VBoolOr t u) = pure $ EBoolOr !(quote env t) !(quote env u)
-  quote env (VBoolEQ t u) = pure $ EBoolEQ !(quote env t) !(quote env u)
-  quote env (VBoolNE t u) = pure $ EBoolNE !(quote env t) !(quote env u)
-  quote env (VBoolIf b t f) = pure $ EBoolIf !(quote env b) !(quote env t) !(quote env f)
-  quote env VNatural = Right $ ENatural
-  quote env (VNaturalLit k) = Right $ ENaturalLit k
-  quote env (VNaturalBuild x) = qApp env ENaturalBuild x
-  quote env (VNaturalFold w x y z) = qAppM env ENaturalFold [w, x, y, z]
-  quote env (VNaturalIsZero x) = qApp env ENaturalIsZero x
-  quote env (VNaturalEven x) = qApp env ENaturalEven x
-  quote env (VNaturalOdd x) = qApp env ENaturalOdd x
-  quote env (VNaturalToInteger x) = qApp env ENaturalToInteger x
-  quote env (VNaturalSubtract x y) = qAppM env ENaturalSubtract [x, y]
-  quote env (VNaturalShow x) = qApp env ENaturalShow x
-  quote env (VNaturalPlus t u) = Right $ ENaturalPlus !(quote env t) !(quote env u)
-  quote env (VNaturalTimes t u) = Right $ ENaturalTimes !(quote env t) !(quote env u)
-  quote env VInteger = Right $ EInteger
-  quote env (VIntegerLit x) = Right $ EIntegerLit x
-  quote env (VIntegerShow x) = qApp env EIntegerShow x
-  quote env (VIntegerNegate x) = qApp env EIntegerNegate x
-  quote env (VIntegerClamp x) = qApp env EIntegerClamp x
-  quote env (VIntegerToDouble x) = qApp env EIntegerToDouble x
-  quote env VDouble = Right $ EDouble
-  quote env (VDoubleLit x) = Right $ EDoubleLit x
-  quote env (VDoubleShow x) = qApp env EDoubleShow x
-  quote env VText = Right $ EText
-  quote env (VTextLit (MkVChunks xs x)) =
+  quote env (VBool fc) = pure $ EBool initFC
+  quote env (VBoolLit fc b) = pure $ EBoolLit initFC b
+  quote env (VBoolAnd fc t u) = pure $ EBoolAnd initFC !(quote env t) !(quote env u)
+  quote env (VBoolOr fc t u) = pure $ EBoolOr initFC !(quote env t) !(quote env u)
+  quote env (VBoolEQ fc t u) = pure $ EBoolEQ initFC !(quote env t) !(quote env u)
+  quote env (VBoolNE fc t u) = pure $ EBoolNE initFC !(quote env t) !(quote env u)
+  quote env (VBoolIf fc b t f) = pure $ EBoolIf initFC !(quote env b) !(quote env t) !(quote env f)
+  quote env (VNatural fc) = Right $ ENatural initFC
+  quote env (VNaturalLit fc k) = Right $ ENaturalLit initFC k
+  quote env (VNaturalBuild fc x) = qApp env ENaturalBuild initFC x
+  quote env (VNaturalFold fc w x y z) = qAppM env ENaturalFold initFC [w, x, y, z]
+  quote env (VNaturalIsZero fc x) = qApp env ENaturalIsZero initFC x
+  quote env (VNaturalEven fc x) = qApp env ENaturalEven initFC x
+  quote env (VNaturalOdd fc x) = qApp env ENaturalOdd initFC x
+  quote env (VNaturalToInteger fc x) = qApp env ENaturalToInteger initFC x
+  quote env (VNaturalSubtract x y) = qAppM env ENaturalSubtract initFC [x, y]
+  quote env (VNaturalShow fc x) = qApp env ENaturalShow initFC x
+  quote env (VNaturalPlus fc t u) = Right $ ENaturalPlus initFC !(quote env t) !(quote env u)
+  quote env (VNaturalTimes fc t u) = Right $ ENaturalTimes initFC !(quote env t) !(quote env u)
+  quote env (VInteger fc) = Right $ EInteger initFC
+  quote env (VIntegerLit fc x) = Right $ EIntegerLit initFC x
+  quote env (VIntegerShow fc x) = qApp env EIntegerShow initFC x
+  quote env (VIntegerNegate fc x) = qApp env EIntegerNegate initFC x
+  quote env (VIntegerClamp fc x) = qApp env EIntegerClamp initFC x
+  quote env (VIntegerToDouble fc x) = qApp env EIntegerToDouble initFC x
+  quote env (VDouble fc) = Right $ EDouble initFC
+  quote env (VDoubleLit fc x) = Right $ EDoubleLit initFC x
+  quote env (VDoubleShow fc x) = qApp env EDoubleShow initFC x
+  quote env (VText fc) = Right $ EText initFC
+  quote env (VTextLit fc (MkVChunks xs x)) =
     let chx = traverse (mapChunks (quote env)) xs in
-    Right $ ETextLit (MkChunks !chx x)
-  quote env (VTextAppend t u) = pure $ ETextAppend !(quote env t) !(quote env u)
-  quote env (VTextShow t) = qApp env ETextShow t
-  quote env (VTextReplace t u v) = qAppM env ETextReplace [t, u, v]
-  quote env (VList x) = qApp env EList x
-  quote env (VListLit Nothing ys) =
+    Right $ ETextLit initFC (MkChunks !chx x)
+  quote env (VTextAppend fc t u) = pure $ ETextAppend initFC !(quote env t) !(quote env u)
+  quote env (VTextShow fc t) = qApp env ETextShow initFC t
+  quote env (VTextReplace fc t u v) = qAppM env ETextReplace initFC [t, u, v]
+  quote env (VList fc x) = qApp env EList initFC x
+  quote env (VListLit fc Nothing ys) =
     let ys' = traverse (quote env) ys in
-    Right $ EListLit Nothing !ys'
-  quote env (VListLit (Just x) ys) =
+    Right $ EListLit initFC Nothing !ys'
+  quote env (VListLit fc (Just x) ys) =
     let ys' = traverse (quote env) ys in
-    Right $ EListLit (Just !(quote env x)) !ys'
-  quote env (VListAppend x y) = Right $ EListAppend !(quote env x) !(quote env y)
-  quote env (VListBuild t u) = qAppM env EListBuild [t, u]
-  quote env (VListFold a l t u v) = qAppM env EListFold [a, l, t, u, v]
-  quote env (VListLength t u) = qAppM env EListLength [t, u]
-  quote env (VListHead t u) = qAppM env EListHead [t, u]
-  quote env (VListLast t u) = qAppM env EListLast [t, u]
-  quote env (VListIndexed t u) = qAppM env EListIndexed [t, u]
-  quote env (VListReverse t u) = qAppM env EListReverse [t, u]
-  quote env (VOptional x) = qApp env EOptional x
-  quote env (VNone x) = qApp env ENone x
-  quote env (VSome x) = Right $ ESome !(quote env x)
-  quote env (VEquivalent x y) = Right $ EEquivalent !(quote env x) !(quote env y)
-  quote env (VAssert x) = Right $ EAssert !(quote env x)
-  quote env (VRecord x) =
+    Right $ EListLit initFC (Just !(quote env x)) !ys'
+  quote env (VListAppend fc x y) = Right $ EListAppend initFC !(quote env x) !(quote env y)
+  quote env (VListBuild fc t u) = qAppM env EListBuild initFC [t, u]
+  quote env (VListFold fc a l t u v) = qAppM env EListFold initFC [a, l, t, u, v]
+  quote env (VListLength fc t u) = qAppM env EListLength initFC [t, u]
+  quote env (VListHead fc t u) = qAppM env EListHead initFC [t, u]
+  quote env (VListLast fc t u) = qAppM env EListLast initFC [t, u]
+  quote env (VListIndexed fc t u) = qAppM env EListIndexed initFC [t, u]
+  quote env (VListReverse fc t u) = qAppM env EListReverse initFC [t, u]
+  quote env (VOptional fc x) = qApp env EOptional initFC x
+  quote env (VNone fc x) = qApp env ENone initFC x
+  quote env (VSome fc x) = Right $ ESome initFC !(quote env x)
+  quote env (VEquivalent fc x y) = Right $ EEquivalent initFC !(quote env x) !(quote env y)
+  quote env (VAssert fc x) = Right $ EAssert initFC !(quote env x)
+  quote env (VRecord fc x) =
     let x' = traverse (quote env) x in
-    Right $ ERecord !x'
-  quote env (VRecordLit x) =
+    Right $ ERecord initFC !x'
+  quote env (VRecordLit fc x) =
     let x' = traverse (quote env) x in
-    Right $ ERecordLit !x'
-  quote env (VUnion x) =
+    Right $ ERecordLit initFC !x'
+  quote env (VUnion fc x) =
     let x' = traverse (mapMaybe (quote env)) x in
-    Right $ EUnion !x'
-  quote env (VField x y) = Right $ EField !(quote env x) y
-  quote env (VCombine x y) = Right $ ECombine !(quote env x) !(quote env y)
-  quote env (VCombineTypes x y) = Right $ ECombineTypes !(quote env x) !(quote env y)
-  quote env (VPrefer x y) = Right $ EPrefer !(quote env x) !(quote env y)
-  quote env (VMerge x y Nothing) = pure $ EMerge !(quote env x) !(quote env y) Nothing
-  quote env (VMerge x y (Just z)) = pure $ EMerge !(quote env x) !(quote env y) (Just !(quote env z))
-  quote env (VToMap x Nothing) = pure $ EToMap !(quote env x) Nothing
-  quote env (VToMap x (Just y)) = pure $ EToMap !(quote env x) (Just !(quote env y))
-  quote env (VInject m k Nothing) =
+    Right $ EUnion initFC !x'
+  quote env (VField fc x y) = Right $ EField initFC !(quote env x) y
+  quote env (VCombine fc x y) = Right $ ECombine initFC !(quote env x) !(quote env y)
+  quote env (VCombineTypes fc x y) = Right $ ECombineTypes initFC !(quote env x) !(quote env y)
+  quote env (VPrefer fc x y) = Right $ EPrefer !(quote env x) !(quote env y)
+  quote env (VMerge fc x y Nothing) = pure $ EMerge !(quote env x) !(quote env y) Nothing
+  quote env (VMerge fc x y (Just z)) = pure $ EMerge !(quote env x) !(quote env y) (Just !(quote env z))
+  quote env (VToMap fc x Nothing) = pure $ EToMap !(quote env x) Nothing
+  quote env (VToMap fc x (Just y)) = pure $ EToMap !(quote env x) (Just !(quote env y))
+  quote env (VInject fc m k Nothing) =
     let m' = traverse (mapMaybe (quote env)) m in
     Right $ EField (EUnion !m') k
-  quote env (VInject m k (Just t)) =
+  quote env (VInject fc m k (Just t)) =
     let m' = traverse (mapMaybe (quote env)) m in
     qApp env (EField (EUnion !m') k) t
-  quote env (VProject t (Left ks)) = pure $ EProject !(quote env t) (Left ks)
-  quote env (VProject t (Right u)) = pure $ EProject !(quote env t) (Right $ !(quote env u))
-  quote env (VWith t ks u) = pure $ EWith !(quote env t) ks !(quote env u)
-  quote env VPrimVar = Left $ ReadBackError "Can't quote VPrimVar"
+  quote env (VProject fc t (Left ks)) = pure $ EProject !(quote env t) (Left ks)
+  quote env (VProject fc t (Right u)) = pure $ EProject !(quote env t) (Right $ !(quote env u))
+  quote env (VWith fc t ks u) = pure $ EWith !(quote env t) ks !(quote env u)
+  quote env (VPrimVar fc) = Left $ ReadBackError "Can't quote VPrimVar"
 
 ||| destruct VPi and VHPi
 vAnyPi : Value -> Either Error (Name, Ty, (Value -> Either Error Value))

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -96,10 +96,10 @@ mutual
   quote env (VList fc x) = qApp fc env (EList fc) x
   quote env (VListLit fc Nothing ys) =
     let ys' = traverse (quote env) ys in
-    Right $ EListLit initFC Nothing !ys'
+    Right $ EListLit fc Nothing !ys'
   quote env (VListLit fc (Just x) ys) =
     let ys' = traverse (quote env) ys in
-    Right $ EListLit initFC (Just !(quote env x)) !ys'
+    Right $ EListLit fc (Just !(quote env x)) !ys'
   quote env (VListAppend fc x y) = Right $ EListAppend fc !(quote env x) !(quote env y)
   quote env (VListBuild fc t u) = qAppM fc env (EListBuild fc) [t, u]
   quote env (VListFold fc a l t u v) = qAppM fc env (EListFold fc) [a, l, t, u, v]

--- a/Idrall/Check.idr
+++ b/Idrall/Check.idr
@@ -18,133 +18,133 @@ where
   go acc (x' :: xs) = go (if x == x' then acc + 1 else acc) xs
 
 fresh : Name -> List Name -> (Name, Value)
-fresh x env = (x, VVar x (countName' x env))
+fresh x env = (x, VVar initFC x (countName' x env))
 
 freshCl : Closure -> List Name -> (Name, Value, Closure)
 freshCl cl@(MkClosure x _ _) env = (x, snd (fresh x env), cl)
 
 mutual
-  qVar : Name -> Int -> List Name -> Expr Void
-  qVar x i env = EVar initFC x ((countName' x env) - i - 1)
+  qVar : FC -> Name -> Int -> List Name -> Expr Void
+  qVar fc x i env = EVar fc x ((countName' x env) - i - 1)
 
   quoteBind : Name -> List Name -> Value -> Either Error (Expr Void)
   quoteBind x env = quote (x :: env)
 
-  qApp : List Name -> Expr Void -> Value -> Either Error (Expr Void)
-  qApp env t VPrimVar = Right $ t
-  qApp env t u        = Right $ EApp t !(quote env u)
+  qApp : FC -> List Name -> Expr Void -> Value -> Either Error (Expr Void)
+  qApp _ env t (VPrimVar fc) = Right $ t
+  qApp fc env t u        = Right $ EApp fc t !(quote env u)
 
   -- Prelude.foldlM : (Foldable t, Monad m) => (a -> b -> m a) -> a -> t b -> m a
-  qAppM : List Name -> Expr Void -> List Value -> Either Error (Expr Void)
-  qAppM env x args = foldlM (qApp env) x args
+  qAppM : FC -> List Name -> Expr Void -> List Value -> Either Error (Expr Void)
+  qAppM fc env x args = foldlM (qApp fc env) x args
 
   export
   quote : List Name -> Value -> Either Error (Expr Void)
-  quote env (VConst fc k) = Right $ EConst k
-  quote env (VVar fc x i) = Right $ qVar x i env
-  quote env (VApp fc t u) = qApp env !(quote env t) u
+  quote env (VConst fc k) = Right $ EConst fc k
+  quote env (VVar fc x i) = Right $ qVar fc x i env
+  quote env (VApp fc t u) = qApp fc env !(quote env t) u
   quote env (VLambda fc a b) =
     let (x, v, t) = freshCl b env in
-        Right $ ELam x !(quote env a) !(quoteBind x env !(inst t v))
+        Right $ ELam fc x !(quote env a) !(quoteBind x env !(inst t v))
   quote env (VHLam fc (Typed x a) t) =
     let (x', v) = fresh x env in
-    Right $ ELam x' !(quote env a) !(quoteBind x env !(t v))
+    Right $ ELam fc x' !(quote env a) !(quoteBind x env !(t v))
   quote env (VHLam fc NaturalSubtractZero _) =
-    pure $ EApp ENaturalSubtract (ENaturalLit 0)
-  quote env (VHLam fc _ t) = quote env !(t VPrimVar)
+    pure $ EApp fc (ENaturalSubtract initFC) (ENaturalLit initFC 0)
+  quote env (VHLam fc _ t) = quote env !(t $ VPrimVar initFC)
   quote env (VPi fc a b) =
     let (x, v, b') = freshCl b env in
-        Right $ EPi x !(quote env a) !(quoteBind x env !(inst b' v))
+        Right $ EPi fc x !(quote env a) !(quoteBind x env !(inst b' v))
   quote env (VHPi fc x a b) =
     let (x', v) = fresh x env in
-        Right $ EPi x !(quote env a) !(quoteBind x env !(b v))
-  quote env (VBool fc) = pure $ EBool initFC
-  quote env (VBoolLit fc b) = pure $ EBoolLit initFC b
-  quote env (VBoolAnd fc t u) = pure $ EBoolAnd initFC !(quote env t) !(quote env u)
-  quote env (VBoolOr fc t u) = pure $ EBoolOr initFC !(quote env t) !(quote env u)
-  quote env (VBoolEQ fc t u) = pure $ EBoolEQ initFC !(quote env t) !(quote env u)
-  quote env (VBoolNE fc t u) = pure $ EBoolNE initFC !(quote env t) !(quote env u)
-  quote env (VBoolIf fc b t f) = pure $ EBoolIf initFC !(quote env b) !(quote env t) !(quote env f)
-  quote env (VNatural fc) = Right $ ENatural initFC
-  quote env (VNaturalLit fc k) = Right $ ENaturalLit initFC k
-  quote env (VNaturalBuild fc x) = qApp env ENaturalBuild initFC x
-  quote env (VNaturalFold fc w x y z) = qAppM env ENaturalFold initFC [w, x, y, z]
-  quote env (VNaturalIsZero fc x) = qApp env ENaturalIsZero initFC x
-  quote env (VNaturalEven fc x) = qApp env ENaturalEven initFC x
-  quote env (VNaturalOdd fc x) = qApp env ENaturalOdd initFC x
-  quote env (VNaturalToInteger fc x) = qApp env ENaturalToInteger initFC x
-  quote env (VNaturalSubtract x y) = qAppM env ENaturalSubtract initFC [x, y]
-  quote env (VNaturalShow fc x) = qApp env ENaturalShow initFC x
-  quote env (VNaturalPlus fc t u) = Right $ ENaturalPlus initFC !(quote env t) !(quote env u)
-  quote env (VNaturalTimes fc t u) = Right $ ENaturalTimes initFC !(quote env t) !(quote env u)
-  quote env (VInteger fc) = Right $ EInteger initFC
-  quote env (VIntegerLit fc x) = Right $ EIntegerLit initFC x
-  quote env (VIntegerShow fc x) = qApp env EIntegerShow initFC x
-  quote env (VIntegerNegate fc x) = qApp env EIntegerNegate initFC x
-  quote env (VIntegerClamp fc x) = qApp env EIntegerClamp initFC x
-  quote env (VIntegerToDouble fc x) = qApp env EIntegerToDouble initFC x
-  quote env (VDouble fc) = Right $ EDouble initFC
-  quote env (VDoubleLit fc x) = Right $ EDoubleLit initFC x
-  quote env (VDoubleShow fc x) = qApp env EDoubleShow initFC x
-  quote env (VText fc) = Right $ EText initFC
+        Right $ EPi fc x !(quote env a) !(quoteBind x env !(b v))
+  quote env (VBool fc) = pure $ EBool fc
+  quote env (VBoolLit fc b) = pure $ EBoolLit fc b
+  quote env (VBoolAnd fc t u) = pure $ EBoolAnd fc !(quote env t) !(quote env u)
+  quote env (VBoolOr fc t u) = pure $ EBoolOr fc !(quote env t) !(quote env u)
+  quote env (VBoolEQ fc t u) = pure $ EBoolEQ fc !(quote env t) !(quote env u)
+  quote env (VBoolNE fc t u) = pure $ EBoolNE fc !(quote env t) !(quote env u)
+  quote env (VBoolIf fc b t f) = pure $ EBoolIf fc !(quote env b) !(quote env t) !(quote env f)
+  quote env (VNatural fc) = Right $ ENatural fc
+  quote env (VNaturalLit fc k) = Right $ ENaturalLit fc k
+  quote env (VNaturalBuild fc x) = qApp fc env (ENaturalBuild fc) x
+  quote env (VNaturalFold fc w x y z) = qAppM fc env (ENaturalFold fc) [w, x, y, z]
+  quote env (VNaturalIsZero fc x) = qApp fc env (ENaturalIsZero fc) x
+  quote env (VNaturalEven fc x) = qApp fc env (ENaturalEven fc) x
+  quote env (VNaturalOdd fc x) = qApp fc env (ENaturalOdd fc) x
+  quote env (VNaturalToInteger fc x) = qApp fc env (ENaturalToInteger fc) x
+  quote env (VNaturalSubtract fc x y) = qAppM fc env (ENaturalSubtract fc) [x, y]
+  quote env (VNaturalShow fc x) = qApp fc env (ENaturalShow fc) x
+  quote env (VNaturalPlus fc t u) = Right $ ENaturalPlus fc !(quote env t) !(quote env u)
+  quote env (VNaturalTimes fc t u) = Right $ ENaturalTimes fc !(quote env t) !(quote env u)
+  quote env (VInteger fc) = Right $ EInteger fc
+  quote env (VIntegerLit fc x) = Right $ EIntegerLit fc x
+  quote env (VIntegerShow fc x) = qApp fc env (EIntegerShow fc) x
+  quote env (VIntegerNegate fc x) = qApp fc env (EIntegerNegate fc) x
+  quote env (VIntegerClamp fc x) = qApp fc env (EIntegerClamp fc) x
+  quote env (VIntegerToDouble fc x) = qApp fc env (EIntegerToDouble fc) x
+  quote env (VDouble fc) = Right $ EDouble fc
+  quote env (VDoubleLit fc x) = Right $ EDoubleLit fc x
+  quote env (VDoubleShow fc x) = qApp fc env (EDoubleShow fc) x
+  quote env (VText fc) = Right $ EText fc
   quote env (VTextLit fc (MkVChunks xs x)) =
     let chx = traverse (mapChunks (quote env)) xs in
     Right $ ETextLit initFC (MkChunks !chx x)
-  quote env (VTextAppend fc t u) = pure $ ETextAppend initFC !(quote env t) !(quote env u)
-  quote env (VTextShow fc t) = qApp env ETextShow initFC t
-  quote env (VTextReplace fc t u v) = qAppM env ETextReplace initFC [t, u, v]
-  quote env (VList fc x) = qApp env EList initFC x
+  quote env (VTextAppend fc t u) = pure $ ETextAppend fc !(quote env t) !(quote env u)
+  quote env (VTextShow fc t) = qApp fc env (ETextShow fc) t
+  quote env (VTextReplace fc t u v) = qAppM fc env (ETextReplace fc) [t, u, v]
+  quote env (VList fc x) = qApp fc env (EList fc) x
   quote env (VListLit fc Nothing ys) =
     let ys' = traverse (quote env) ys in
     Right $ EListLit initFC Nothing !ys'
   quote env (VListLit fc (Just x) ys) =
     let ys' = traverse (quote env) ys in
     Right $ EListLit initFC (Just !(quote env x)) !ys'
-  quote env (VListAppend fc x y) = Right $ EListAppend initFC !(quote env x) !(quote env y)
-  quote env (VListBuild fc t u) = qAppM env EListBuild initFC [t, u]
-  quote env (VListFold fc a l t u v) = qAppM env EListFold initFC [a, l, t, u, v]
-  quote env (VListLength fc t u) = qAppM env EListLength initFC [t, u]
-  quote env (VListHead fc t u) = qAppM env EListHead initFC [t, u]
-  quote env (VListLast fc t u) = qAppM env EListLast initFC [t, u]
-  quote env (VListIndexed fc t u) = qAppM env EListIndexed initFC [t, u]
-  quote env (VListReverse fc t u) = qAppM env EListReverse initFC [t, u]
-  quote env (VOptional fc x) = qApp env EOptional initFC x
-  quote env (VNone fc x) = qApp env ENone initFC x
-  quote env (VSome fc x) = Right $ ESome initFC !(quote env x)
-  quote env (VEquivalent fc x y) = Right $ EEquivalent initFC !(quote env x) !(quote env y)
-  quote env (VAssert fc x) = Right $ EAssert initFC !(quote env x)
+  quote env (VListAppend fc x y) = Right $ EListAppend fc !(quote env x) !(quote env y)
+  quote env (VListBuild fc t u) = qAppM fc env (EListBuild fc) [t, u]
+  quote env (VListFold fc a l t u v) = qAppM fc env (EListFold fc) [a, l, t, u, v]
+  quote env (VListLength fc t u) = qAppM fc env (EListLength fc) [t, u]
+  quote env (VListHead fc t u) = qAppM fc env (EListHead fc) [t, u]
+  quote env (VListLast fc t u) = qAppM fc env (EListLast fc) [t, u]
+  quote env (VListIndexed fc t u) = qAppM fc env (EListIndexed fc) [t, u]
+  quote env (VListReverse fc t u) = qAppM fc env (EListReverse fc) [t, u]
+  quote env (VOptional fc x) = qApp fc env (EOptional fc) x
+  quote env (VNone fc x) = qApp fc env (ENone fc) x
+  quote env (VSome fc x) = Right $ ESome fc !(quote env x)
+  quote env (VEquivalent fc x y) = Right $ EEquivalent fc !(quote env x) !(quote env y)
+  quote env (VAssert fc x) = Right $ EAssert fc !(quote env x)
   quote env (VRecord fc x) =
     let x' = traverse (quote env) x in
-    Right $ ERecord initFC !x'
+    Right $ ERecord fc !x'
   quote env (VRecordLit fc x) =
     let x' = traverse (quote env) x in
-    Right $ ERecordLit initFC !x'
+    Right $ ERecordLit fc !x'
   quote env (VUnion fc x) =
     let x' = traverse (mapMaybe (quote env)) x in
-    Right $ EUnion initFC !x'
-  quote env (VField fc x y) = Right $ EField initFC !(quote env x) y
-  quote env (VCombine fc x y) = Right $ ECombine initFC !(quote env x) !(quote env y)
-  quote env (VCombineTypes fc x y) = Right $ ECombineTypes initFC !(quote env x) !(quote env y)
-  quote env (VPrefer fc x y) = Right $ EPrefer !(quote env x) !(quote env y)
-  quote env (VMerge fc x y Nothing) = pure $ EMerge !(quote env x) !(quote env y) Nothing
-  quote env (VMerge fc x y (Just z)) = pure $ EMerge !(quote env x) !(quote env y) (Just !(quote env z))
-  quote env (VToMap fc x Nothing) = pure $ EToMap !(quote env x) Nothing
-  quote env (VToMap fc x (Just y)) = pure $ EToMap !(quote env x) (Just !(quote env y))
+    Right $ EUnion fc !x'
+  quote env (VCombine fc x y) = Right $ ECombine fc !(quote env x) !(quote env y)
+  quote env (VCombineTypes fc x y) = Right $ ECombineTypes fc !(quote env x) !(quote env y)
+  quote env (VPrefer fc x y) = Right $ EPrefer fc !(quote env x) !(quote env y)
+  quote env (VMerge fc x y Nothing) = pure $ EMerge fc !(quote env x) !(quote env y) Nothing
+  quote env (VMerge fc x y (Just z)) = pure $ EMerge fc !(quote env x) !(quote env y) (Just !(quote env z))
+  quote env (VToMap fc x Nothing) = pure $ EToMap fc !(quote env x) Nothing
+  quote env (VToMap fc x (Just y)) = pure $ EToMap fc !(quote env x) (Just !(quote env y))
+  quote env (VField fc x y) = Right $ EField fc !(quote env x) y
   quote env (VInject fc m k Nothing) =
     let m' = traverse (mapMaybe (quote env)) m in
-    Right $ EField (EUnion !m') k
+    Right $ EField fc (EUnion initFC !m') k
   quote env (VInject fc m k (Just t)) =
     let m' = traverse (mapMaybe (quote env)) m in
-    qApp env (EField (EUnion !m') k) t
-  quote env (VProject fc t (Left ks)) = pure $ EProject !(quote env t) (Left ks)
-  quote env (VProject fc t (Right u)) = pure $ EProject !(quote env t) (Right $ !(quote env u))
-  quote env (VWith fc t ks u) = pure $ EWith !(quote env t) ks !(quote env u)
+    qApp fc env (EField fc (EUnion initFC !m') k) t
+  quote env (VProject fc t (Left ks)) = pure $ EProject fc !(quote env t) (Left ks)
+  quote env (VProject fc t (Right u)) = pure $ EProject fc !(quote env t) (Right $ !(quote env u))
+  quote env (VWith fc t ks u) = pure $ EWith fc !(quote env t) ks !(quote env u)
   quote env (VPrimVar fc) = Left $ ReadBackError "Can't quote VPrimVar"
 
 ||| destruct VPi and VHPi
 vAnyPi : Value -> Either Error (Name, Ty, (Value -> Either Error Value))
-vAnyPi (VHPi x a b) = Right (x, a, b)
-vAnyPi (VPi a b@(MkClosure x _ _)) = Right (x, a, inst b)
+vAnyPi (VHPi fc x a b) = Right (x, a, b)
+vAnyPi (VPi fc a b@(MkClosure x _ _)) = Right (x, a, inst b)
 vAnyPi t = Left $ Unexpected $ show t ++ " is not a VPi or VHPi"
 
 data Types = TEmpty
@@ -204,28 +204,28 @@ mutual
   checkTy cxt t = do
     (t, a) <- infer cxt t
     case a of
-      VConst c => pure (t, c)
+      VConst fc c => pure (t, c)
       other        => Left $ ErrorMessage $ show other ++ " is not a Type/Kind/Sort"
 
   ||| returns the original `Expr Void` on success
   export
   check : Cxt -> Expr Void -> Value -> Either Error (Expr Void)
-  check cxt (EConst CType) vKype = pure $ EConst CType
-  check cxt (EConst Kind) vSort = pure $ EConst Kind
-  check cxt (EConst Sort) z = Left $ SortError
-  check cxt (ELam x a t) pi =
+  check cxt (EConst fc CType) vKype = pure $ EConst fc CType
+  check cxt (EConst fc Kind) vSort = pure $ EConst fc Kind
+  check cxt (EConst fc Sort) z = Left $ SortError
+  check cxt (ELam fc x a t) pi =
     let (x', v) = fresh x (envNames (values cxt)) in do -- TODO not sure about fresh...
     (_, a', b) <- vAnyPi pi
     (a, _) <- checkTy cxt a
     av <- eval (values cxt) a
     unify cxt av a'
     t <- check (define x' v av cxt) t !(b v)
-    pure $ ELam x a t
-  check cxt (EBoolLit t) VBool = pure $ EBoolLit t
-  check cxt (ENaturalLit t) VNatural = pure $ ENaturalLit t
-  check cxt (EIntegerLit t) VInteger = pure $ EIntegerLit t
-  check cxt (EDoubleLit t) VDouble = pure $ EDoubleLit t
-  check cxt (ETextLit t) VText = pure $ ETextLit t
+    pure $ ELam fc x a t
+  check cxt (EBoolLit fc t) (VBool fc') = pure $ EBoolLit fc t
+  check cxt (ENaturalLit fc t) (VNatural fc') = pure $ ENaturalLit fc t
+  check cxt (EIntegerLit fc t) (VInteger fc') = pure $ EIntegerLit fc t
+  check cxt (EDoubleLit fc t) (VDouble fc') = pure $ EDoubleLit fc t
+  check cxt (ETextLit fc t) (VText fc') = pure $ ETextLit fc t
   -- check cxt (ERecordLit y) z = ?check_rhs TODO maybe add this later for performance?
   check cxt t a = do
     (t, a') <- infer cxt t
@@ -235,344 +235,344 @@ mutual
   unexpected : String -> Value -> Either Error a
   unexpected str v = Left (Unexpected $ str ++ " Value: " ++ show v)
 
-  natFoldTy : Value
-  natFoldTy =
-    VHPi "natural" vType $ \natural =>
-    pure $ VHPi "succ" (vFun natural natural) $ \succ =>
-    pure $ VHPi "zero" natural $ \zero =>
+  natFoldTy : FC -> Value
+  natFoldTy fc =
+    VHPi fc "natural" vType $ \natural =>
+    pure $ VHPi fc "succ" (vFun natural natural) $ \succ =>
+    pure $ VHPi fc "zero" natural $ \zero =>
     pure $ natural
 
-  listFoldTy : Value -> Value
-  listFoldTy a =
-    VHPi "list" vType $ \list =>
-    pure $ VHPi "cons" (vFun a $ vFun list list) $ \cons =>
-    pure $ VHPi "nil" list $ \nil =>
+  listFoldTy : FC -> Value -> Value
+  listFoldTy fc a =
+    VHPi fc "list" vType $ \list =>
+    pure $ VHPi fc "cons" (vFun a $ vFun list list) $ \cons =>
+    pure $ VHPi fc "nil" list $ \nil =>
     pure $ list
 
   ||| returns a pair (Expr, Value), which is original Expr, and it's type as a Value
   export
   infer : Cxt -> Expr Void -> Either Error (Expr Void, Value)
-  infer cxt (EConst k) = (\k' => (EConst k, VConst k')) <$> axiom k
-  infer cxt (EVar x i) = go (types cxt) i
+  infer cxt (EConst fc k) = (\k' => (EConst fc k, VConst fc k')) <$> axiom k
+  infer cxt (EVar fc x i) = go (types cxt) i
   where
     go : Types -> Int -> Either Error (Expr Void, Value)
     go TEmpty n = Left $ MissingVar $ x ++ "@" ++ show i ++ "\n in Cxt: " ++ show cxt
     go (TBind ts x' a) n =
       case x == x' of
-           True => if n == 0 then Right (EVar x i, a) else go ts (n - 1)
+           True => if n == 0 then Right (EVar fc x i, a) else go ts (n - 1)
            False => go ts n
-  infer cxt (ELam x a t) = do
+  infer cxt (ELam fc x a t) = do
     (a, ak) <- checkTy cxt a
     av <- eval (values cxt) a
     (t, b) <- infer (bind x av cxt) t
     nb <- quote (x :: (envNames (values cxt))) b
-    Right ( ELam x a t
-          , VHPi x av $
+    Right ( ELam fc x a t
+          , VHPi fc x av $
             \u => Right $ !(eval (Extend (values cxt) x u) nb)) -- TODO check i'm using values right
-  infer cxt (EPi x a b) = do
+  infer cxt (EPi fc x a b) = do
     (a, ak) <- checkTy cxt a
     av <- eval (values cxt) a
     (b, bk) <- checkTy (bind x av cxt) b
-    Right (EPi x a b, VConst $ rule ak bk)
-  infer cxt (EApp t u) = do
+    Right (EPi fc x a b, VConst fc $ rule ak bk)
+  infer cxt (EApp fc t u) = do
     (t, tt) <- infer cxt t
     (x, a, b) <- vAnyPi tt
     _ <- check cxt u a
-    Right $ (EApp t u, !(b !(eval (values cxt) u)))
-  infer cxt (ELet x Nothing a b) = do
+    Right $ (EApp fc t u, !(b !(eval (values cxt) u)))
+  infer cxt (ELet fc x Nothing a b) = do
     (a, aa) <- infer cxt a
     v <- eval (values cxt) a
     infer (define x v aa cxt) b
-  infer cxt (ELet x (Just t) a b) = do
+  infer cxt (ELet fc x (Just t) a b) = do
     tt <- eval (values cxt) t
     _ <- check cxt a tt
     v <- eval (values cxt) a
     infer (define x v tt cxt) b
-  infer cxt (EAnnot x t) = do
+  infer cxt (EAnnot fc x t) = do
     tv <- eval (values cxt) t
     _ <- check cxt x tv
-    Right $ (EAnnot x t, tv)
-  infer cxt EBool = Right $ (EBool, VConst CType)
-  infer cxt (EBoolLit x) = Right $ (EBoolLit x, VBool)
-  infer cxt (EBoolAnd x y) = do
-    _ <- check cxt x VBool
-    _ <- check cxt y VBool
-    Right $ (EBoolAnd x y, VBool)
-  infer cxt (EBoolOr x y) = do
-    _ <- check cxt x VBool
-    _ <- check cxt y VBool
-    Right $ (EBoolOr x y, VBool)
-  infer cxt (EBoolEQ x y) = do
-    _ <- check cxt x VBool
-    _ <- check cxt y VBool
-    Right $ (EBoolEQ x y, VBool)
-  infer cxt (EBoolNE x y) = do
-    _ <- check cxt x VBool
-    _ <- check cxt y VBool
-    Right $ (EBoolNE x y, VBool)
-  infer cxt (EBoolIf b t f) = do
-    _ <- check cxt b VBool
+    Right $ (EAnnot fc x t, tv)
+  infer cxt (EBool fc) = Right $ (EBool fc, VConst fc CType)
+  infer cxt (EBoolLit fc x) = Right $ (EBoolLit fc x, VBool fc)
+  infer cxt (EBoolAnd fc x y) = do
+    _ <- check cxt x (VBool fc)
+    _ <- check cxt y (VBool fc)
+    Right $ (EBoolAnd fc x y, VBool fc)
+  infer cxt (EBoolOr fc x y) = do
+    _ <- check cxt x (VBool initFC)
+    _ <- check cxt y (VBool initFC)
+    Right $ (EBoolOr fc x y, VBool fc)
+  infer cxt (EBoolEQ fc x y) = do
+    _ <- check cxt x (VBool initFC)
+    _ <- check cxt y (VBool initFC)
+    Right $ (EBoolEQ fc x y, VBool fc)
+  infer cxt (EBoolNE fc x y) = do
+    _ <- check cxt x (VBool initFC)
+    _ <- check cxt y (VBool initFC)
+    Right $ (EBoolNE fc x y, VBool fc)
+  infer cxt (EBoolIf fc b t f) = do
+    _ <- check cxt b (VBool initFC)
     (t, tt) <- infer cxt t
     _ <- check cxt f tt
-    Right $ (EBoolIf b t f, tt)
-  infer cxt ENatural = Right $ (ENatural, VConst CType)
-  infer cxt (ENaturalLit k) = Right $ (ENaturalLit k, VNatural)
-  infer cxt ENaturalBuild = pure (ENaturalBuild, vFun natFoldTy VNatural)
-  infer cxt ENaturalFold = pure (ENaturalFold, vFun VNatural natFoldTy)
-  infer cxt ENaturalIsZero = Right $ (ENaturalIsZero, (vFun VNatural VBool))
-  infer cxt ENaturalEven = Right $ (ENaturalEven, (vFun VNatural VBool))
-  infer cxt ENaturalOdd = Right $ (ENaturalOdd, (vFun VNatural VBool))
-  infer cxt ENaturalSubtract = Right $ (ENaturalOdd, (vFun VNatural (vFun VNatural VNatural)))
-  infer cxt ENaturalToInteger = Right $ (ENaturalToInteger, (vFun VNatural VInteger))
-  infer cxt ENaturalShow = Right $ (ENaturalShow, (vFun VNatural VText))
-  infer cxt (ENaturalPlus t u) = do
-    _ <- check cxt t VNatural
-    _ <- check cxt u VNatural
-    Right $ (ENaturalPlus t u, VNatural)
-  infer cxt (ENaturalTimes t u) = do
-    _ <- check cxt t VNatural
-    _ <- check cxt u VNatural
-    Right $ (ENaturalTimes t u, VNatural)
-  infer cxt EInteger = Right $ (EInteger, VConst CType)
-  infer cxt (EIntegerLit x) = Right $ (EIntegerLit x, VInteger)
-  infer cxt EIntegerShow = Right $ (EIntegerShow, (vFun VInteger VText))
-  infer cxt EIntegerNegate = Right $ (EIntegerNegate, (vFun VInteger VInteger))
-  infer cxt EIntegerClamp = Right $ (EIntegerNegate, (vFun VInteger VNatural))
-  infer cxt EIntegerToDouble = Right $ (EIntegerNegate, (vFun VInteger VDouble))
-  infer cxt EDouble = Right $ (EDouble, VConst CType)
-  infer cxt (EDoubleLit x) = Right $ (EDoubleLit x, VDouble)
-  infer cxt EDoubleShow = Right $ (EDoubleShow, (vFun VDouble VText))
-  infer cxt EText = Right $ (EText, VConst CType)
-  infer cxt (ETextLit (MkChunks xs x)) =
-    let go = mapChunks (\e => check cxt e VText) in do
+    Right $ (EBoolIf fc b t f, tt)
+  infer cxt (ENatural fc) = Right $ (ENatural fc, VConst fc CType)
+  infer cxt (ENaturalLit fc k) = Right $ (ENaturalLit fc k, VNatural initFC)
+  infer cxt (ENaturalBuild fc) = Right $ (ENaturalBuild fc, vFun (natFoldTy initFC) (VNatural initFC))
+  infer cxt (ENaturalFold fc) = pure (ENaturalFold fc, vFun (VNatural initFC) (natFoldTy initFC))
+  infer cxt (ENaturalIsZero fc) = Right $ (ENaturalIsZero fc, (vFun (VNatural initFC) (VBool initFC)))
+  infer cxt (ENaturalEven fc) = Right $ (ENaturalEven fc, (vFun (VNatural initFC) (VBool initFC)))
+  infer cxt (ENaturalOdd fc) = Right $ (ENaturalOdd fc, (vFun (VNatural initFC) (VBool initFC)))
+  infer cxt (ENaturalSubtract fc) = Right $ (ENaturalOdd fc, (vFun (VNatural initFC) (vFun (VNatural initFC) (VNatural initFC))))
+  infer cxt (ENaturalToInteger fc) = Right $ (ENaturalToInteger fc, (vFun (VNatural initFC) (VInteger initFC)))
+  infer cxt (ENaturalShow fc) = Right $ (ENaturalShow fc, (vFun (VNatural initFC) (VText initFC)))
+  infer cxt (ENaturalPlus fc t u) = do
+    _ <- check cxt t (VNatural initFC)
+    _ <- check cxt u (VNatural initFC)
+    Right $ (ENaturalPlus fc t u, VNatural fc)
+  infer cxt (ENaturalTimes fc t u) = do
+    _ <- check cxt t (VNatural initFC)
+    _ <- check cxt u (VNatural initFC)
+    Right $ (ENaturalTimes fc t u, VNatural fc)
+  infer cxt (EInteger fc) = Right $ (EInteger fc, VConst fc CType)
+  infer cxt (EIntegerLit fc x) = Right $ (EIntegerLit fc x, VInteger initFC)
+  infer cxt (EIntegerShow fc) = Right $ (EIntegerShow fc, (vFun (VInteger initFC) (VText initFC)))
+  infer cxt (EIntegerNegate fc) = Right $ (EIntegerNegate fc, (vFun (VInteger initFC) (VInteger initFC)))
+  infer cxt (EIntegerClamp fc) = Right $ (EIntegerNegate fc, (vFun (VInteger initFC) (VNatural initFC)))
+  infer cxt (EIntegerToDouble fc) = Right $ (EIntegerNegate fc, (vFun (VInteger initFC) (VDouble initFC)))
+  infer cxt (EDouble fc) = Right $ (EDouble fc, VConst fc CType)
+  infer cxt (EDoubleLit fc x) = Right $ (EDoubleLit fc x, VDouble initFC)
+  infer cxt (EDoubleShow fc) = Right $ (EDoubleShow fc, (vFun (VDouble initFC) (VText initFC)))
+  infer cxt (EText fc) = Right $ (EText fc, VConst initFC CType)
+  infer cxt (ETextLit fc (MkChunks xs x)) =
+    let go = mapChunks (\e => check cxt e (VText initFC)) in do
     _ <- traverse go xs
-    Right $ (ETextLit (MkChunks xs x), VText)
-  infer cxt (ETextAppend t u) = do
-    _ <- check cxt t VText
-    _ <- check cxt u VText
-    pure $ (ETextAppend t u, VText)
-  infer cxt ETextShow = pure $ (EIntegerShow, (vFun VText VText))
-  infer cxt ETextReplace =
-    pure ( ETextReplace,
-           VHPi "needle" VText $ \needle =>
-           pure $ VHPi "replacement" VText $ \replacement =>
-           pure $ VHPi "haystack" VText $ \haystack =>
-           pure VText)
-  infer cxt EList = do
-    Right $ (EList, VHPi "a" vType $ \a => Right $ vType)
-  infer cxt (EListLit Nothing []) = do
+    Right $ (ETextLit fc (MkChunks xs x), (VText initFC))
+  infer cxt (ETextAppend fc t u) = do
+    _ <- check cxt t (VText initFC)
+    _ <- check cxt u (VText initFC)
+    pure $ (ETextAppend fc t u, VText initFC)
+  infer cxt (ETextShow fc) = pure $ (EIntegerShow fc, (vFun (VText initFC) (VText initFC)))
+  infer cxt (ETextReplace fc) =
+    pure ( ETextReplace fc,
+           VHPi fc "needle" (VText initFC) $ \needle =>
+           pure $ VHPi fc "replacement" (VText initFC) $ \replacement =>
+           pure $ VHPi fc "haystack" (VText initFC) $ \haystack =>
+           pure $ VText initFC)
+  infer cxt (EList fc) = do
+    Right $ (EList fc, VHPi fc "a" vType $ \a => Right $ vType)
+  infer cxt (EListLit fc Nothing []) = do
     Left $ ErrorMessage "Not type for list" -- TODO better error message
-  infer cxt (EListLit Nothing (x :: xs)) = do
+  infer cxt (EListLit fc Nothing (x :: xs)) = do
     (x', ty) <- infer cxt x
     _ <- traverse (\e => check cxt e ty) xs
-    Right $ (EListLit Nothing (x :: xs), VList ty)
-  infer cxt (EListLit (Just a) []) = do
+    Right $ (EListLit fc Nothing (x :: xs), VList fc ty)
+  infer cxt (EListLit fc (Just a) []) = do
     case !(eval (values cxt) a) of
-         VList a' => do
+         VList _ a' => do
            ea' <- quote (envNames $ values cxt) a'
-           _ <- check cxt ea' (VConst CType)
-           Right $ (EListLit (Just a) [], VList a')
+           _ <- check cxt ea' (VConst initFC CType)
+           Right $ (EListLit fc (Just a) [], VList fc a')
          other => Left $ ErrorMessage $ "Not a list annotation: " ++ show other
-  infer cxt (EListLit (Just a) (x :: xs)) = do
+  infer cxt (EListLit fc (Just a) (x :: xs)) = do
     ty <- eval (values cxt) a
     (a', av) <- infer cxt x
     _ <- traverse (\e => check cxt e av) xs
-    _ <- conv (values cxt) ty (VList av)
-    Right $ (EListLit (Just a) (x :: xs), ty)
-  infer cxt (EListAppend t u) = do
+    _ <- conv (values cxt) ty (VList initFC av)
+    Right $ (EListLit fc (Just a) (x :: xs), ty)
+  infer cxt (EListAppend fc t u) = do
     (t', tt) <- infer cxt t
     case tt of
-         (VList x) => do
+         (VList _ x) => do
            _ <- check cxt u tt
-           Right $ (EListAppend t u, tt)
+           Right $ (EListAppend fc t u, tt)
          _ => Left $ ListAppendError "not a list" -- TODO better error message
-  infer cxt EListBuild =
-    pure (EListBuild, VHPi "a" vType $ \a => pure $ vFun (listFoldTy a) (VList a))
-  infer cxt EListFold =
-    pure (EListFold, VHPi "a" vType $ \a => pure $ vFun (VList a) (listFoldTy a))
-  infer cxt EListLength =
-    pure (EListLength, VHPi "a" vType $ \a => pure $ vFun (VList a) VNatural)
-  infer cxt EListHead =
-    pure (EListHead, VHPi "a" vType $ \a => pure $ vFun (VList a) (VOptional a))
-  infer cxt EListLast =
-    pure (EListLast, VHPi "a" vType $ \a => pure $ vFun (VList a) (VOptional a))
-  infer cxt EListIndexed =
-    pure (EListIndexed
-         , VHPi "a" vType $ \a =>
-           pure $ vFun (VList a)
-                  (VList (VRecord (fromList [(MkFieldName "index", VNatural), (MkFieldName "value", a)]))))
-  infer cxt EListReverse =
-    pure (EListReverse, VHPi "a" vType $ \a => pure $ vFun (VList a) (VList a))
-  infer cxt EOptional =
-    Right $ (EOptional, VHPi "a" vType $ \a => Right $ vType)
-  infer cxt (ESome t) = do
+  infer cxt (EListBuild fc) =
+    pure (EListBuild fc, VHPi fc "a" vType $ \a => pure $ vFun (listFoldTy fc a) (VList fc a))
+  infer cxt (EListFold fc) =
+    pure (EListFold fc, VHPi fc "a" vType $ \a => pure $ vFun (VList fc a) (listFoldTy fc a))
+  infer cxt (EListLength fc) =
+    pure (EListLength fc, VHPi fc "a" vType $ \a => pure $ vFun (VList fc a) (VNatural fc))
+  infer cxt (EListHead fc) =
+    pure (EListHead fc, VHPi fc "a" vType $ \a => pure $ vFun (VList fc a) (VOptional fc a))
+  infer cxt (EListLast fc) =
+    pure (EListLast fc, VHPi fc "a" vType $ \a => pure $ vFun (VList fc a) (VOptional fc a))
+  infer cxt (EListIndexed fc) =
+    pure (EListIndexed fc
+         , VHPi fc "a" vType $ \a =>
+           pure $ vFun (VList fc a)
+                  (VList fc (VRecord initFC (fromList [(MkFieldName "index", VNatural initFC), (MkFieldName "value", a)]))))
+  infer cxt (EListReverse fc) =
+    pure (EListReverse fc, VHPi fc "a" vType $ \a => pure $ vFun (VList initFC a) (VList initFC a))
+  infer cxt (EOptional fc) =
+    Right $ (EOptional fc, VHPi fc "a" vType $ \a => Right $ vType)
+  infer cxt (ESome fc t) = do
     (t, tt) <- infer cxt t
     _ <- check cxt !(quote (envNames $ values cxt) tt) vType -- TODO abstract this out?
-    pure (ESome t, VOptional tt)
-  infer cxt ENone =
-    Right $ (ENone, VHPi "a" vType $ \a => Right $ (VOptional a))
-  infer cxt e@(EEquivalent t u) = do
+    pure (ESome fc t, VOptional fc tt)
+  infer cxt (ENone fc) =
+    Right $ (ENone fc, VHPi fc "a" vType $ \a => Right $ (VOptional fc a))
+  infer cxt e@(EEquivalent fc t u) = do
     (t, tt) <- infer cxt t
     _ <- check cxt u tt
     -- conv (values cxt) tt vType TODO
     Right (e, vType)
-  infer cxt (EAssert (EEquivalent a b)) = do
+  infer cxt (EAssert fc (EEquivalent fc' a b)) = do
     (a, aa) <- infer cxt a
     av <- eval (values cxt) a
     bv <- eval (values cxt) b
     conv (values cxt) av bv
-    pure (EAssert (EEquivalent a b), VEquivalent av bv)
-  infer cxt (EAssert _) = Left $ AssertError "not an EEquivalent type" -- TODO better error message
-  infer cxt (ERecord x) = do
+    pure (EAssert fc (EEquivalent fc' a b), VEquivalent fc' av bv)
+  infer cxt (EAssert fc _) = Left $ AssertError "not an EEquivalent type" -- TODO better error message
+  infer cxt (ERecord fc x) = do
     xs' <- traverse (inferSkip cxt) x
-    Right $ (ERecord x, VConst (getHighestType xs'))
-  infer cxt (ERecordLit x) = do
+    Right $ (ERecord fc x, VConst fc (getHighestType xs'))
+  infer cxt (ERecordLit fc x) = do
     xs' <- traverse (inferSkip cxt) x
-    Right $ (ERecordLit x, VRecord xs')
-  infer cxt (EUnion x) = do
+    Right $ (ERecordLit fc x, VRecord fc xs')
+  infer cxt (EUnion fc x) = do
     xs' <- traverse (mapMaybe (inferSkip cxt)) x
-    Right $ (EUnion x, VConst (getHighestTypeM xs'))
-  infer cxt (ECombine t u) = do
+    Right $ (EUnion fc x, VConst fc (getHighestTypeM xs'))
+  infer cxt (ECombine fc t u) = do
     (t, tt) <- infer cxt t
     (u, uu) <- infer cxt u
     case (tt, uu) of
-         (VRecord a', VRecord b') => do
-           ty <- mergeWithApp doCombine a' b'
-           Right $ (ECombine t u, VRecord ty)
-         (VRecord _, other) => unexpected "Not a RecordLit" other
+         (VRecord _ a', VRecord _ b') => do
+           ty <- mergeWithApp (doCombine fc) a' b'
+           Right $ (ECombine fc t u, VRecord fc ty)
+         (VRecord _ _, other) => unexpected "Not a RecordLit" other
          (other, _) => unexpected "Not a RecordLit" other
-  infer cxt (ECombineTypes a b) = do -- TODO lot of traversals here
+  infer cxt (ECombineTypes fc a b) = do -- TODO lot of traversals here
     av <- eval (values cxt) a
     bv <- eval (values cxt) b
     case (av, bv) of
-         (VRecord a', VRecord b') => do
-           ty <- mergeWithApp doCombine a' b'
-           Right $ (ECombineTypes a b, snd !(infer cxt !(quote (envNames $ values cxt) (VRecord ty))))
+         (VRecord _ a', VRecord _ b') => do
+           ty <- mergeWithApp (doCombine fc) a' b'
+           Right $ (ECombineTypes fc a b, snd !(infer cxt !(quote (envNames $ values cxt) (VRecord fc ty))))
          (other, _) => unexpected "Not a Record" other
-  infer cxt (EPrefer t u) = do
+  infer cxt (EPrefer fc t u) = do
     (t, tt) <- infer cxt t
     (u, uu) <- infer cxt u
     case (tt, uu) of
-         (VRecord a', VRecord b') => do
-           ty <- mergeWithApp' doCombine a' b'
-           Right $ (EPrefer t u, VRecord ty)
-         (VRecord _, other) => unexpected "Not a RecordLit" other
+         (VRecord _ a', VRecord _ b') => do
+           ty <- mergeWithApp' (doCombine fc) a' b'
+           Right $ (EPrefer fc t u, VRecord fc ty)
+         (VRecord _ _, other) => unexpected "Not a RecordLit" other
          (other, _) => unexpected "Not a RecordLit" other
-  infer cxt (EMerge t u a) = do
+  infer cxt (EMerge fc t u a) = do
     (u, ut) <- infer cxt u
     (t, tt) <- infer cxt t
     case (ut, tt) of
-         (VUnion ts, VRecord us) => do
+         (VUnion _ ts, VRecord _ us) => do
            case a of
                 Nothing => do
-                  pure (EMerge t u a, !(inferMerge cxt ts us Nothing))
+                  pure (EMerge fc t u a, !(inferMerge cxt ts us Nothing))
                 (Just a') => do
                   av <- eval (values cxt) a'
                   ty <- inferMerge cxt ts us (Just av)
                   conv (values cxt) av ty
-                  pure (EMerge t u a, av)
-         (VOptional a', VRecord us) =>
+                  pure (EMerge fc t u a, av)
+         (VOptional _ a', VRecord _ us) =>
            let newUnion = SortedMap.fromList $
                             [(MkFieldName "None", Nothing), (MkFieldName "Some", Just a')]
-           in pure (EMerge t u a, !(inferMerge cxt newUnion us Nothing))
-         (other, VRecord _) => unexpected "Not a RecordLit or Optional" other
+           in pure (EMerge fc t u a, !(inferMerge cxt newUnion us Nothing))
+         (other, VRecord _ _) => unexpected "Not a RecordLit or Optional" other
          (_, other) => unexpected "Not a RecordLit" other
-  infer cxt (EToMap t a) = do
+  infer cxt (EToMap fc t a) = do
     (t, tt) <- infer cxt t
     case tt of
-         (VRecord ms) =>
+         (VRecord _ ms) =>
            let xs = SortedMap.toList ms in
            case (xs, a) of
                 (((k, v) :: ys), Just x) => do
                   _ <- unifyAllValues cxt v ys
                   _ <- unify cxt (toMapTy v) !(eval (values cxt) x)
-                  pure (EToMap t a, toMapTy v)
+                  pure (EToMap fc t a, toMapTy v)
                 (((k, v) :: ys), Nothing) => do
                   _ <- unifyAllValues cxt v ys
-                  pure (EToMap t a, toMapTy v)
+                  pure (EToMap fc t a, toMapTy v)
                 ([], Just x) => do v <- checkToMapAnnot cxt !(eval (values cxt) x)
-                                   pure (EToMap t a, v)
+                                   pure (EToMap fc t a, v)
                 ([], Nothing) => Left $ ToMapEmpty "Needs an annotation"
          other => unexpected "Not a RecordLit" other
   where
     unifyAllValues : Cxt -> Value -> List (FieldName, Value) -> Either Error Value
     unifyAllValues cxt v vs = do
-      unify cxt !(inferSkip cxt !(quote (envNames $ values cxt) v)) (VConst CType)
+      unify cxt !(inferSkip cxt !(quote (envNames $ values cxt) v)) (VConst initFC CType)
       _ <- foldlM (\x,y => unify cxt x y *> pure x) v (map snd vs)
       pure v
     checkToMapAnnot : Cxt -> Value -> Either Error Value
-    checkToMapAnnot cxt v@(VList (VRecord ms)) =
+    checkToMapAnnot cxt v@(VList fc (VRecord fc' ms)) =
       case SortedMap.toList ms of
-           (((MkFieldName "mapKey"), VText) :: ((MkFieldName "mapValue"), a) :: []) => do
+           (((MkFieldName "mapKey"), VText initFC) :: ((MkFieldName "mapValue"), a) :: []) => do
              _ <- checkTy cxt !(quote (envNames $ values cxt) a)
              pure v
            other => Left $ ToMapError $ "wrong annotation type" ++ show other
     checkToMapAnnot cxt other = Left $ ToMapError $ "wrong annotation type: " ++ show other
-  infer cxt (EField t k) = do
+  infer cxt (EField fc t k) = do
     (t, tt) <- infer cxt t
     case tt of
-         (VConst _) =>
+         (VConst _ _) =>
             case !(eval (values cxt) t) of
-                 VUnion ts =>
+                 VUnion _ ts =>
                     case lookup k ts of
-                         (Just Nothing) => pure $ (EField t k, VUnion ts)
-                         (Just (Just a)) => pure $ (EField t k, vFun a (VUnion ts))
+                         (Just Nothing) => pure $ (EField fc t k, VUnion fc ts)
+                         (Just (Just a)) => pure $ (EField fc t k, vFun a (VUnion fc ts))
                          Nothing => Left $ FieldNotFoundError $ show k
                  x => Left (InvalidFieldType (show t))
-         (VRecord ts) =>
+         (VRecord _ ts) =>
             case lookup k ts of
-                 (Just a) => pure $ (EField t k, a)
+                 (Just a) => pure $ (EField fc t k, a)
                  Nothing => Left $ FieldNotFoundError $ show k
          _ => Left (InvalidFieldType (show t))
-  infer cxt (ERecordCompletion t u) = do
+  infer cxt (ERecordCompletion fc t u) = do
     (t, tt) <- infer cxt t
     case tt of
-         (VRecord ms) => do
+         (VRecord _ ms) => do
            -- guard $ mapErr "Type" (go (MkFieldName "Type") ms)
            -- guard $ mapErr "default" (go (MkFieldName "default") ms)
            case (lookup (MkFieldName "Type") ms, lookup (MkFieldName "default") ms) of
                 (Just x, Just y) =>
-                  infer cxt (EAnnot (EPrefer (EField t (MkFieldName "default")) u) (EField t (MkFieldName "Type")))
+                  infer cxt (EAnnot fc (EPrefer fc (EField fc t (MkFieldName "default")) u) (EField fc t (MkFieldName "Type")))
                 (other, (Just _)) => Left $ InvalidRecordCompletion "Type"
                 (_, other) => Left $ InvalidRecordCompletion "default"
          other => unexpected "Not a RecordLit" other
-  infer cxt (EProject t (Left ks)) = do
+  infer cxt (EProject fc t (Left ks)) = do
     (t, tt) <- infer cxt t
     case tt of
-         (VRecord ms) =>
-           pure (EProject t (Left ks), VRecord $ fromList !(vProjectByFields ms ks))
+         (VRecord _ ms) =>
+           pure (EProject fc t (Left ks), VRecord fc $ fromList !(vProjectByFields ms ks))
          (other) => unexpected "Not a RecordLit" other
-  infer cxt (EProject t (Right a)) = do
+  infer cxt (EProject fc t (Right a)) = do
     (t, tt) <- infer cxt t
     av <- eval (values cxt) a
     case (tt, av) of
-         (VRecord ms, VRecord ms') => do
-           pure (EProject t (Right a), VRecord $ fromList !(vProjectByFields ms (keys ms')))
-         (other, VRecord _) => unexpected "Not a RecordLit" other
+         (VRecord _ ms, VRecord _ ms') => do
+           pure (EProject fc t (Right a), VRecord fc $ fromList !(vProjectByFields ms (keys ms')))
+         (other, VRecord _ _) => unexpected "Not a RecordLit" other
          (_, other) => unexpected "Not a Record" other
-  infer cxt (EWith t ks u) = do -- TODO understand this
+  infer cxt (EWith fc t ks u) = do -- TODO understand this
     (t, tt) <- infer cxt t
-    pure (EWith t ks u, !(inferWith tt ks u))
+    pure (EWith fc t ks u, !(inferWith tt ks u))
   where
     inferWith : Value -> List1 FieldName -> Expr Void -> Either Error Value
-    inferWith (VRecord ms) ks y =
+    inferWith (VRecord fc ms) ks y =
       case ks of
            (head ::: []) => do
              (u, uu) <- infer cxt u
-             pure $ VRecord $ insert head uu ms
+             pure $ VRecord fc $ insert head uu ms
            (head ::: (k :: ks)) => do
              let v = case lookup head ms of
-                      Nothing => VRecord (fromList [])
+                      Nothing => VRecord fc (fromList [])
                       (Just v) => v
              v' <- inferWith v (k ::: ks) y
-             pure $ VRecord $ insert head v' ms
+             pure $ VRecord fc $ insert head v' ms
     inferWith other _ _ = unexpected "Not a RecordLit" other
-  infer cxt (EImportAlt x y) = infer cxt x
-  infer cxt (EEmbed (Raw x)) = absurd x
-  infer cxt (EEmbed (Resolved x)) = infer initCxt x
+  infer cxt (EImportAlt fc x y) = infer cxt x
+  infer cxt (EEmbed fc (Raw x)) = absurd x
+  infer cxt (EEmbed fc (Resolved x)) = infer initCxt x
 
   toMapTy : Value -> Value
-  toMapTy v = VList $ VRecord $ fromList [(MkFieldName "mapKey", VText), (MkFieldName "mapValue", v)]
+  toMapTy v = VList initFC $ VRecord initFC $ fromList [(MkFieldName "mapKey", VText initFC), (MkFieldName "mapValue", v)]
 
   checkEmptyMerge : Maybe Value -> Either Error Value
   checkEmptyMerge Nothing = Left $ EmptyMerge "Needs a type annotation"
@@ -621,8 +621,8 @@ mutual
   inferSkip cxt = (\e => Right $ snd !(infer cxt e))
 
   pickHigherType : (acc : U) -> Ty -> U
-  pickHigherType CType (VConst Kind) = Kind
-  pickHigherType _ (VConst Sort) = Sort
+  pickHigherType CType (VConst _ Kind) = Kind
+  pickHigherType _ (VConst _ Sort) = Sort
   pickHigherType acc other = acc
 
   getHighestTypeM : Foldable t => t (Maybe Value) -> U

--- a/Idrall/Derive.idr
+++ b/Idrall/Derive.idr
@@ -113,22 +113,22 @@ interface FromDhall a where
 
 export
 FromDhall Nat where
-  fromDhall (ENaturalLit x) = pure x
+  fromDhall (ENaturalLit fc x) = pure x
   fromDhall _ = neutral
 
 export
 FromDhall Bool where
-  fromDhall (EBoolLit x) = pure x
+  fromDhall (EBoolLit fc x) = pure x
   fromDhall _ = neutral
 
 export
 FromDhall Integer where
-  fromDhall (EIntegerLit x) = pure x
+  fromDhall (EIntegerLit fc x) = pure x
   fromDhall _ = neutral
 
 export
 FromDhall Double where
-  fromDhall (EDoubleLit x) = pure x
+  fromDhall (EDoubleLit fc x) = pure x
   fromDhall _ = neutral
 
 export
@@ -137,14 +137,14 @@ FromDhall String where
 
 export
 FromDhall a => FromDhall (List a) where
-  fromDhall (EListLit _ xs) = pure $ !(traverse fromDhall xs)
+  fromDhall (EListLit fc _ xs) = pure $ !(traverse fromDhall xs)
   fromDhall _ = neutral
 
 export
 FromDhall a => FromDhall (Maybe a) where
-  fromDhall (ESome x) =
+  fromDhall (ESome fc x) =
     pure $ fromDhall x
-  fromDhall (EApp ENone _) = pure $ neutral
+  fromDhall (EApp fc (ENone fc') _) = pure $ neutral
   fromDhall _ = neutral
 
 ||| Used with FromDhall interface, to dervice implementations
@@ -210,7 +210,7 @@ deriveFromDhall it n =
       let cn = primStr (show $ stripNs constructor')
           debug = show $ constructor'
           debug2 = show $ map fst xs
-          lhs = `(~(var funName) (EApp (EField (EUnion xs) (MkFieldName ~cn)) ~(bindvar $ show arg)))
+          lhs = `(~(var funName) (EApp _ (EField _ (EUnion _ xs) (MkFieldName ~cn)) ~(bindvar $ show arg)))
           in do
           case xs of
                [] => pure $ (lhs, `(pure ~(var constructor')))
@@ -225,5 +225,5 @@ deriveFromDhall it n =
       -- given constructors, lookup names in dhall records for those constructors
       clausesRecord <- traverse (\(cn, as) => genClauseRecord cn arg (reverse as)) cons
       -- create clause from dhall to `Maybe a` using the above clauses as the rhs
-      pure $ pure $ patClause `(~(var funName) (ERecordLit ~(bindvar $ show arg)))
+      pure $ pure $ patClause `(~(var funName) (ERecordLit _ ~(bindvar $ show arg)))
                               (foldl (\acc, x => `(~x <|> ~acc)) `(Nothing) (clausesRecord))

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -48,6 +48,11 @@ Show FC where
   show (MkVirtualFC x y z) = "MkVirtualFCTODO"
   show EmptyFC = "(,)"
 
+
+public export
+initFC : FC
+initFC = EmptyFC
+
 public export
 Namespace : Type
 Namespace = List (Name, Integer)

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -26,6 +26,29 @@ Ord FieldName where
   compare (MkFieldName x) (MkFieldName y) = compare x y
 
 public export
+FilePos : Type
+FilePos = (Nat, Nat)
+
+-- does fancy stuff for idris, for now it can just be a Maybe filename
+
+public export
+OriginDesc : Type
+OriginDesc = Maybe String
+
+public export
+data FC = MkFC        OriginDesc FilePos FilePos
+        | ||| Virtual FCs are FC attached to desugared/generated code.
+          MkVirtualFC OriginDesc FilePos FilePos
+        | EmptyFC
+%name FC fc
+
+Show FC where
+  show (MkFC Nothing x y) = "\{show x}-\{show y}"
+  show (MkFC (Just s) x y) = "\{s}:\{show x}-\{show y}"
+  show (MkVirtualFC x y z) = "MkVirtualFCTODO"
+  show EmptyFC = "(,)"
+
+public export
 Namespace : Type
 Namespace = List (Name, Integer)
 %name Namespace ns1, ns2, ns3
@@ -68,146 +91,146 @@ mutual
   public export
   data Expr a
     -- x
-    = EConst U
-    | EVar Name Int
+    = EConst FC U
+    | EVar FC Name Int
     -- | ELam x A b ~ λ(x : A) -> b
-    | ELam Name (Expr a) (Expr a)
+    | ELam FC Name (Expr a) (Expr a)
     -- | EPi x A b ~ forall(x : A) -> b
-    | EPi Name (Expr a) (Expr a)
+    | EPi FC Name (Expr a) (Expr a)
     -- | > EApp f a ~ f a
-    | EApp (Expr a) (Expr a)
+    | EApp FC (Expr a) (Expr a)
     -- | > ELet x Nothing r e ~ let x = r in e
     --   > ELet x (Just t) r e ~ let x : t = r in e
-    | ELet Name (Maybe (Expr a)) (Expr a) (Expr a)
+    | ELet FC Name (Maybe (Expr a)) (Expr a) (Expr a)
     -- | > EAnnot x t ~ x : t
-    | EAnnot (Expr a) (Expr a)
+    | EAnnot FC (Expr a) (Expr a)
     -- | > EBool ~ Bool
-    | EBool
+    | EBool FC
     -- | > EBoolLit b ~ b
-    | EBoolLit Bool
+    | EBoolLit FC Bool
     -- | > EBoolAnd x y ~ x && y
-    | EBoolAnd (Expr a) (Expr a)
+    | EBoolAnd FC (Expr a) (Expr a)
     -- | > EBoolOr  x y ~  x || y
-    | EBoolOr  (Expr a) (Expr a)
+    | EBoolOr FC (Expr a) (Expr a)
     -- | > EBoolEQ  x y ~  x == y
-    | EBoolEQ  (Expr a) (Expr a)
+    | EBoolEQ FC (Expr a) (Expr a)
     -- | > EBoolNE  x y ~  x != y
-    | EBoolNE  (Expr a) (Expr a)
+    | EBoolNE FC (Expr a) (Expr a)
     -- | > EBoolIf x y z ~ if x then y else z
-    | EBoolIf (Expr a) (Expr a) (Expr a)
+    | EBoolIf FC (Expr a) (Expr a) (Expr a)
     -- | > ENatural ~ Natural
-    | ENatural
+    | ENatural FC
     -- | > ENaturalLit n ~ n
-    | ENaturalLit Nat
+    | ENaturalLit FC Nat
     -- | > ENaturalFold ~ Natural/fold
-    | ENaturalFold
+    | ENaturalFold FC
     -- | > ENaturalBuild ~ Natural/build
-    | ENaturalBuild
+    | ENaturalBuild FC
     -- | > ENaturalIsZero ~ Natural/isZero
-    | ENaturalIsZero
+    | ENaturalIsZero FC
     -- | > ENaturalEven ~  Natural/even
-    | ENaturalEven
+    | ENaturalEven FC
     -- | > ENaturalOdd ~  Natural/odd
-    | ENaturalOdd
+    | ENaturalOdd FC
     -- | > ENaturalToInteger ~  Natural/toInteger
-    | ENaturalToInteger
+    | ENaturalToInteger FC
     -- | > ENaturalSubtract ~  Natural/subtract
-    | ENaturalSubtract
+    | ENaturalSubtract FC
     -- | > ENaturalShow ~  Natural/show
-    | ENaturalShow
+    | ENaturalShow FC
      -- | > ENaturalPlus x y ~  x + y
-    | ENaturalPlus (Expr a) (Expr a)
+    | ENaturalPlus FC (Expr a) (Expr a)
     -- | > ENaturalTimes x y ~  x * y
-    | ENaturalTimes (Expr a) (Expr a)
+    | ENaturalTimes FC (Expr a) (Expr a)
     -- | > EInteger ~ Integer
-    | EInteger
+    | EInteger FC
     -- | > EIntegerLit i ~ i
-    | EIntegerLit Integer
+    | EIntegerLit FC Integer
     -- | > EIntegerShow ~  Integer/show
-    | EIntegerShow
+    | EIntegerShow FC
     -- | > EIntegerClamp ~ Integer/clamp
-    | EIntegerClamp
+    | EIntegerClamp FC
     -- | > EIntegerNegate ~ EIntegerNegate
-    | EIntegerNegate
+    | EIntegerNegate FC
     -- | > EIntegerToDouble ~ EIntegerToDouble
-    | EIntegerToDouble
+    | EIntegerToDouble FC
     -- | > EDouble ~ Double
-    | EDouble
+    | EDouble FC
     -- | > EDoubleLit n ~ n
-    | EDoubleLit Double
+    | EDoubleLit FC Double
     -- | > EDoubleShow ~  Double/show
-    | EDoubleShow
+    | EDoubleShow FC
     -- | > EText ~ Text
-    | EText
+    | EText FC
     -- | > ETextLit (Chunks [(t1, e1), (t2, e2)] t3) ~  "t1${e1}t2${e2}t3"
-    | ETextLit (Chunks a)
+    | ETextLit FC (Chunks a)
     -- | > ETextAppend x y ~ x ++ y
-    | ETextAppend (Expr a) (Expr a)
+    | ETextAppend FC (Expr a) (Expr a)
     -- | > ETextShow ~ Text/show
-    | ETextShow
+    | ETextShow FC
     -- | > ETextReplace ~ Text/replace
-    | ETextReplace
+    | ETextReplace FC
     -- | > EList a ~ List a
-    | EList
+    | EList FC
     -- | > EList (Some e) [e', ...] ~ [] : List a
-    | EListLit (Maybe (Expr a)) (List (Expr a))
+    | EListLit FC (Maybe (Expr a)) (List (Expr a))
     -- | > EListAppend x y ~ x # y
-    | EListAppend (Expr a) (Expr a)
+    | EListAppend FC (Expr a) (Expr a)
     -- | > EListBuild ~ List/build
-    | EListBuild
+    | EListBuild FC
     -- | > EListFold ~ List/fold
-    | EListFold
+    | EListFold FC
     -- | > EListLength ~ List/length
-    | EListLength
+    | EListLength FC
     -- | > EListHead ~ List/head
-    | EListHead
+    | EListHead FC
     -- | > EListLast ~ List/last
-    | EListLast
+    | EListLast FC
     -- | > EListIndexed ~ List/indexed
-    | EListIndexed
+    | EListIndexed FC
     -- | > EListReverse ~ List/reverse
-    | EListReverse
+    | EListReverse FC
     -- | > EOptional ~ Optional
-    | EOptional
+    | EOptional FC
     -- | > ESome x ~ Some a
-    | ESome (Expr a)
+    | ESome FC (Expr a)
     -- | > ENone ~ None
-    | ENone
+    | ENone FC
     -- | > EEquivalent x y ~ x === y
-    | EEquivalent (Expr a) (Expr a)
+    | EEquivalent FC (Expr a) (Expr a)
     -- | > EAssert x ~ assert : e
-    | EAssert (Expr a)
+    | EAssert FC (Expr a)
     -- | > ERecord (fromList ((MkFieldName "Foo"), EBool)) ~ { Foo : Bool }
-    | ERecord (SortedMap FieldName (Expr a))
+    | ERecord FC (SortedMap FieldName (Expr a))
     -- | > ERecordLit (fromList ((MkFieldName "Foo"), EBool)) ~ { Foo = Bool }
-    | ERecordLit (SortedMap FieldName (Expr a))
+    | ERecordLit FC (SortedMap FieldName (Expr a))
     -- | > EUnion (fromList ((MkFieldName "Foo"), Nothing)) ~ < Foo >
     -- | > EUnion (fromList ((MkFieldName "Foo"), Just EBool)) ~ < Foo : Bool >
-    | EUnion (SortedMap FieldName (Maybe (Expr a)))
+    | EUnion FC (SortedMap FieldName (Maybe (Expr a)))
     -- | > ECombine x y ~ x /\ y
-    | ECombine (Expr a) (Expr a)
+    | ECombine FC (Expr a) (Expr a)
     -- | > ECombineTypes x y ~ x //\\ y
-    | ECombineTypes (Expr a) (Expr a)
+    | ECombineTypes FC (Expr a) (Expr a)
     -- | > EPrefer x y ~  x ⫽ y
-    | EPrefer (Expr a) (Expr a)
+    | EPrefer FC (Expr a) (Expr a)
     -- | > ERecordCompletion x y ~  x::y
-    | ERecordCompletion (Expr a) (Expr a)
+    | ERecordCompletion FC (Expr a) (Expr a)
     -- | > EMerge x y (Just t ) ~  merge x y : t
     --   > EMerge x y  Nothing  ~  merge x y
-    | EMerge (Expr a) (Expr a) (Maybe (Expr a))
+    | EMerge FC (Expr a) (Expr a) (Maybe (Expr a))
     -- | > EToMap x (Just t) ~  toMap x : t
     --   > EToMap x Nothing ~  toMap x
-    | EToMap (Expr a) (Maybe (Expr a))
+    | EToMap FC (Expr a) (Maybe (Expr a))
     -- | > EField (EVar "x" 0) (MkFieldName "Foo") ~ x.Foo
-    | EField (Expr a) FieldName
+    | EField FC (Expr a) FieldName
     -- | > EProject e (Left xs) ~ e.{ xs }
     --   > EProject e (Right t) ~ e.(t)
-    | EProject (Expr a) (Either (List FieldName) (Expr a))
+    | EProject FC (Expr a) (Either (List FieldName) (Expr a))
     -- | > EWith x y e ~  x with y = e
-    | EWith (Expr a) (List1 FieldName) (Expr a)
+    | EWith FC (Expr a) (List1 FieldName) (Expr a)
     -- | > EImportAlt x y ~ x ? y
-    | EImportAlt (Expr a) (Expr a)
-    | EEmbed (Import a)
+    | EImportAlt FC (Expr a) (Expr a)
+    | EEmbed FC (Import a)
 
 export
 Show ImportStatement where
@@ -226,77 +249,77 @@ mutual
 
   export
   Show (Expr a) where
-    show (EConst x) = "(EConst " ++ show x ++ ")"
-    show (EVar x i) = "(EVar " ++ show x ++ " " ++ show i ++ ")"
-    show (ELam x y z) = "(ELam " ++ x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (EPi x y z) = "(EPi " ++ x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (EApp x y) = "(EApp " ++ show x ++ " " ++ show y ++ ")"
-    show (ELet x y z w) = "(ELet " ++ show x ++ " " ++ show y ++ " " ++ show z ++ " " ++ show w ++ ")"
-    show (EAnnot x y) = "(EAnnot " ++ show x ++ " " ++ show y ++ ")"
-    show EBool = "EBool"
-    show (EBoolLit False) = "(EBoolLit False)"
-    show (EBoolLit True) = "(EBoolLit True)"
-    show (EBoolAnd x y) = "(EBoolAnd " ++ show x ++ " " ++ show y ++ ")"
-    show (EBoolOr x y) = "(EBoolOr " ++ show x ++ " " ++ show y ++ ")"
-    show (EBoolEQ x y) = "(EBoolEQ " ++ show x ++ " " ++ show y ++ ")"
-    show (EBoolNE x y) = "(EBoolNE " ++ show x ++ " " ++ show y ++ ")"
-    show (EBoolIf x y z) = "(EBoolIf " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show ENatural = "ENatural"
-    show (ENaturalLit k) = "(ENaturalLit " ++ show k ++ ")"
-    show ENaturalFold = "ENaturalFold"
-    show ENaturalBuild = "ENaturalBuild"
-    show ENaturalIsZero = "ENaturalIsZero"
-    show ENaturalEven = "ENaturalEven"
-    show ENaturalOdd = "ENaturalOdd"
-    show ENaturalToInteger = "ENaturalToInteger"
-    show ENaturalSubtract = "ENaturalSubtract"
-    show ENaturalShow = "NaturalShow"
-    show (ENaturalPlus x y) = "(ENaturalPlus " ++ show x ++ " " ++ show y ++ ")"
-    show (ENaturalTimes x y) = "(ENaturalTimes " ++ show x ++ " " ++ show y ++ ")"
-    show EInteger = "EInteger"
-    show (EIntegerLit x) = "(EIntegerLit " ++ show x ++ ")"
-    show EIntegerClamp = "EIntegerClamp"
-    show EIntegerShow = "EIntegerShow"
-    show EIntegerNegate = "EIntegerNegate"
-    show EIntegerToDouble = "EIntegerToDouble"
-    show EDouble = "EDouble"
-    show (EDoubleLit k) = "(EDoubleLit " ++ show k ++ ")"
-    show EDoubleShow = "EDoubleShow"
-    show EText = "EText"
-    show (ETextLit x) = "(ETextLit " ++ show x ++ ")"
-    show (ETextAppend x y) = "(ETextAppend " ++ show x ++ " " ++ show y ++ ")"
-    show ETextShow = "ETextShow"
-    show ETextReplace = "ETextReplace"
-    show EList = "EList"
-    show (EListLit Nothing xs) = "(EListLit Nothing " ++ show xs ++ ")"
-    show (EListLit (Just x) xs) = "(EListLit (Just " ++ show x ++ ") " ++ show xs ++ ")"
-    show (EListAppend x y) = "(EListAppend " ++ show x ++ " " ++ show y ++ ")"
-    show EListBuild = "EListBuild"
-    show EListFold = "EListFold"
-    show EListHead = "EListHead"
-    show EListLength = "EListLength"
-    show EListLast = "EListLast"
-    show EListIndexed = "EListIndexed"
-    show EListReverse = "EListReverse"
-    show EOptional = "EOptional"
-    show ENone = "ENone"
-    show (ESome x) = "(ESome " ++ show x ++ ")"
-    show (EEquivalent x y) = "(EEquivalent " ++ show x ++ " " ++ show y ++ ")"
-    show (EAssert x) = "(EAssert " ++ show x ++ ")"
-    show (ERecord x) = "(ERecord " ++ show x ++ ")"
-    show (ERecordLit x) = "(ERecordLit " ++ show x ++ ")"
-    show (EUnion x) = "(EUnion $ " ++ show x ++ ")"
-    show (ECombine x y) = "(ECombine " ++ show x ++ " " ++ show y ++ ")"
-    show (ECombineTypes x y) = "(ECombineTypes " ++ show x ++ " " ++ show y ++ ")"
-    show (EPrefer x y) = "(EPrefer " ++ show x ++ " " ++ show y ++ ")"
-    show (ERecordCompletion x y) = "(ERecordCompletion " ++ show x ++ " " ++ show y ++ ")"
-    show (EMerge x y z) = "(EMerge " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (EToMap x y) = "(EToMap " ++ show x ++ " " ++ show y ++ ")"
-    show (EField x y) = "(EField " ++ show x ++ " " ++ show y ++ ")"
-    show (EProject x y) = "(EProject " ++ show x ++ " " ++ show y ++ ")"
-    show (EWith x ks y) = "(EWith " ++ show x ++ " " ++ show ks ++ " " ++ show y ++ ")"
-    show (EImportAlt x y) = "(EImportAlt " ++ show x ++ " " ++ show y ++ ")"
-    show (EEmbed x) = "(EEmbed " ++ show x ++ ")"
+    show (EConst fc x) = "(EConst " ++ show x ++ ")"
+    show (EVar fc x i) = "(EVar " ++ show x ++ " " ++ show i ++ ")"
+    show (ELam fc x y z) = "(ELam " ++ x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (EPi fc x y z) = "(EPi " ++ x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (EApp fc x y) = "(EApp " ++ show x ++ " " ++ show y ++ ")"
+    show (ELet fc x y z w) = "(ELet " ++ show x ++ " " ++ show y ++ " " ++ show z ++ " " ++ show w ++ ")"
+    show (EAnnot fc x y) = "(EAnnot " ++ show x ++ " " ++ show y ++ ")"
+    show (EBool fc) = "EBool"
+    show (EBoolLit fc False) = "(EBoolLit False)"
+    show (EBoolLit fc True) = "(EBoolLit True)"
+    show (EBoolAnd fc x y) = "(EBoolAnd " ++ show x ++ " " ++ show y ++ ")"
+    show (EBoolOr fc x y) = "(EBoolOr " ++ show x ++ " " ++ show y ++ ")"
+    show (EBoolEQ fc x y) = "(EBoolEQ " ++ show x ++ " " ++ show y ++ ")"
+    show (EBoolNE fc x y) = "(EBoolNE " ++ show x ++ " " ++ show y ++ ")"
+    show (EBoolIf fc x y z) = "(EBoolIf " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (ENatural fc) = "ENatural"
+    show (ENaturalLit fc k) = "(ENaturalLit " ++ show k ++ ")"
+    show (ENaturalFold fc) = "ENaturalFold"
+    show (ENaturalBuild fc) = "ENaturalBuild"
+    show (ENaturalIsZero fc) = "ENaturalIsZero"
+    show (ENaturalEven fc) = "ENaturalEven"
+    show (ENaturalOdd fc) = "ENaturalOdd"
+    show (ENaturalToInteger fc) = "ENaturalToInteger"
+    show (ENaturalSubtract fc) = "ENaturalSubtract"
+    show (ENaturalShow fc) = "NaturalShow"
+    show (ENaturalPlus fc x y) = "(ENaturalPlus " ++ show x ++ " " ++ show y ++ ")"
+    show (ENaturalTimes fc x y) = "(ENaturalTimes " ++ show x ++ " " ++ show y ++ ")"
+    show (EInteger fc) = "EInteger"
+    show (EIntegerLit fc x) = "(EIntegerLit " ++ show x ++ ")"
+    show (EIntegerClamp fc) = "EIntegerClamp"
+    show (EIntegerShow fc) = "EIntegerShow"
+    show (EIntegerNegate fc) = "EIntegerNegate"
+    show (EIntegerToDouble fc) = "EIntegerToDouble"
+    show (EDouble fc) = "EDouble"
+    show (EDoubleLit fc k) = "(EDoubleLit " ++ show k ++ ")"
+    show (EDoubleShow fc) = "EDoubleShow"
+    show (EText fc) = "EText"
+    show (ETextLit fc x) = "(ETextLit " ++ show x ++ ")"
+    show (ETextAppend fc x y) = "(ETextAppend " ++ show x ++ " " ++ show y ++ ")"
+    show (ETextShow fc) = "ETextShow"
+    show (ETextReplace fc) = "ETextReplace"
+    show (EList fc) = "EList"
+    show (EListLit fc Nothing xs) = "(EListLit Nothing " ++ show xs ++ ")"
+    show (EListLit fc (Just x) xs) = "(EListLit (Just " ++ show x ++ ") " ++ show xs ++ ")"
+    show (EListAppend fc x y) = "(EListAppend " ++ show x ++ " " ++ show y ++ ")"
+    show (EListBuild fc) = "EListBuild"
+    show (EListFold fc) = "EListFold"
+    show (EListHead fc) = "EListHead"
+    show (EListLength fc) = "EListLength"
+    show (EListLast fc) = "EListLast"
+    show (EListIndexed fc) = "EListIndexed"
+    show (EListReverse fc) = "EListReverse"
+    show (EOptional fc) = "EOptional"
+    show (ENone fc) = "ENone"
+    show (ESome fc x) = "(ESome " ++ show x ++ ")"
+    show (EEquivalent fc x y) = "(EEquivalent " ++ show x ++ " " ++ show y ++ ")"
+    show (EAssert fc x) = "(EAssert " ++ show x ++ ")"
+    show (ERecord fc x) = "(ERecord " ++ show x ++ ")"
+    show (ERecordLit fc x) = "(ERecordLit " ++ show x ++ ")"
+    show (EUnion fc x) = "(EUnion $ " ++ show x ++ ")"
+    show (ECombine fc x y) = "(ECombine " ++ show x ++ " " ++ show y ++ ")"
+    show (ECombineTypes fc x y) = "(ECombineTypes " ++ show x ++ " " ++ show y ++ ")"
+    show (EPrefer fc x y) = "(EPrefer " ++ show x ++ " " ++ show y ++ ")"
+    show (ERecordCompletion fc x y) = "(ERecordCompletion " ++ show x ++ " " ++ show y ++ ")"
+    show (EMerge fc x y z) = "(EMerge " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (EToMap fc x y) = "(EToMap " ++ show x ++ " " ++ show y ++ ")"
+    show (EField fc x y) = "(EField " ++ show x ++ " " ++ show y ++ ")"
+    show (EProject fc x y) = "(EProject " ++ show x ++ " " ++ show y ++ ")"
+    show (EWith fc x ks y) = "(EWith " ++ show x ++ " " ++ show ks ++ " " ++ show y ++ ")"
+    show (EImportAlt fc x y) = "(EImportAlt " ++ show x ++ " " ++ show y ++ ")"
+    show (EEmbed fc x) = "(EEmbed " ++ show x ++ ")"
 
   public export
   Show (Chunks a) where

--- a/Idrall/Expr.idr
+++ b/Idrall/Expr.idr
@@ -30,10 +30,12 @@ FilePos : Type
 FilePos = (Nat, Nat)
 
 -- does fancy stuff for idris, for now it can just be a Maybe filename
-
 public export
 OriginDesc : Type
 OriginDesc = Maybe String
+
+-- TODO use this as a Maybe for MkVirtualFC
+data FCDetails = MkFCDetails OriginDesc FilePos FilePos
 
 public export
 data FC = MkFC        OriginDesc FilePos FilePos

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -16,65 +16,68 @@ import Idrall.Path
 
 %hide Prelude.pow
 
+initFC : FC
+initFC = EmptyFC
+
 builtin : Parser (Expr ImportStatement)
 builtin =
-  (string "Natural/build" *> pure ENaturalBuild) <|>
-  (string "Natural/fold" *> pure ENaturalFold) <|>
-  (string "Natural/isZero" *> pure ENaturalIsZero) <|>
-  (string "Natural/even" *> pure ENaturalEven) <|>
-  (string "Natural/odd" *> pure ENaturalOdd) <|>
-  (string "Natural/subtract" *> pure ENaturalSubtract) <|>
-  (string "Natural/toInteger" *> pure ENaturalToInteger) <|>
-  (string "Natural/show" *> pure ENaturalShow) <|>
-  (string "Integer/show" *> pure EIntegerShow) <|>
-  (string "Integer/negate" *> pure EIntegerNegate) <|>
-  (string "Integer/clamp" *> pure EIntegerClamp) <|>
-  (string "Integer/toDouble" *> pure EIntegerToDouble) <|>
-  (string "Double/show" *> pure EDoubleShow) <|>
-  (string "List/build" *> pure EListBuild) <|>
-  (string "List/fold" *> pure EListFold) <|>
-  (string "List/length" *> pure EListLength) <|>
-  (string "List/head" *> pure EListHead) <|>
-  (string "List/last" *> pure EListLast) <|>
-  (string "List/indexed" *> pure EListIndexed) <|>
-  (string "List/reverse" *> pure EListReverse) <|>
-  (string "List" *> pure EList) <|>
-  (string "Text/show" *> pure ETextShow) <|>
-  (string "Text/replace" *> pure ETextReplace) <|>
-  (string "None" *> pure ENone) <|>
-  (string "Optional" *> pure EOptional) <|>
-  (string "NaN" *> pure (EDoubleLit (0.0/0.0)))
+  (string "Natural/build" *> pure (ENaturalBuild initFC)) <|>
+  (string "Natural/fold" *> pure (ENaturalFold initFC)) <|>
+  (string "Natural/isZero" *> pure (ENaturalIsZero initFC)) <|>
+  (string "Natural/even" *> pure (ENaturalEven initFC)) <|>
+  (string "Natural/odd" *> pure (ENaturalOdd initFC)) <|>
+  (string "Natural/subtract" *> pure (ENaturalSubtract initFC)) <|>
+  (string "Natural/toInteger" *> pure (ENaturalToInteger initFC)) <|>
+  (string "Natural/show" *> pure (ENaturalShow initFC)) <|>
+  (string "Integer/show" *> pure (EIntegerShow initFC)) <|>
+  (string "Integer/negate" *> pure (EIntegerNegate initFC)) <|>
+  (string "Integer/clamp" *> pure (EIntegerClamp initFC)) <|>
+  (string "Integer/toDouble" *> pure (EIntegerToDouble initFC)) <|>
+  (string "Double/show" *> pure (EDoubleShow initFC)) <|>
+  (string "List/build" *> pure (EListBuild initFC)) <|>
+  (string "List/fold" *> pure (EListFold initFC)) <|>
+  (string "List/length" *> pure (EListLength initFC)) <|>
+  (string "List/head" *> pure (EListHead initFC)) <|>
+  (string "List/last" *> pure (EListLast initFC)) <|>
+  (string "List/indexed" *> pure (EListIndexed initFC)) <|>
+  (string "List/reverse" *> pure (EListReverse initFC)) <|>
+  (string "List" *> pure (EList initFC)) <|>
+  (string "Text/show" *> pure (ETextShow initFC)) <|>
+  (string "Text/replace" *> pure (ETextReplace initFC)) <|>
+  (string "None" *> pure (ENone initFC)) <|>
+  (string "Optional" *> pure (EOptional initFC)) <|>
+  (string "NaN" *> pure (EDoubleLit initFC (0.0/0.0)))
 
 true : Parser (Expr ImportStatement)
-true = string "True" *> pure (EBoolLit True)
+true = string "True" *> pure (EBoolLit initFC True)
 
 false : Parser (Expr ImportStatement)
-false = string "False" *> pure (EBoolLit False)
+false = string "False" *> pure (EBoolLit initFC False)
 
 bool : Parser (Expr ImportStatement)
-bool = string "Bool" *> pure (EBool)
+bool = string "Bool" *> pure (EBool initFC)
 
 text : Parser (Expr ImportStatement)
-text = string "Text" *> pure (EText)
+text = string "Text" *> pure (EText initFC)
 
 integer : Parser (Expr ImportStatement)
-integer = string "Integer" *> pure (EInteger)
+integer = string "Integer" *> pure (EInteger initFC)
 
 integerLit : Parser (Expr ImportStatement)
 integerLit = do op <- (char '-' <|> char '+')
                 x <- some digit
                 case op of
-                     '+' => pure (EIntegerLit (getInteger x))
-                     '-' => pure (EIntegerLit ((getInteger x)*(-1)))
+                     '+' => pure (EIntegerLit initFC (getInteger x))
+                     '-' => pure (EIntegerLit initFC ((getInteger x)*(-1)))
                      _ => fail "not an Integer"
 where getInteger : List (Fin 10) -> Integer
       getInteger = foldl (\a => \b => 10 * a + cast b) 0
 
 natural : Parser (Expr ImportStatement)
-natural = string "Natural" *> pure (ENatural)
+natural = string "Natural" *> pure (ENatural initFC)
 
 double : Parser (Expr ImportStatement)
-double = string "Double" *> pure (EDouble)
+double = string "Double" *> pure (EDouble initFC)
 
 naturalNumber : Parser Nat
 naturalNumber = do n <- some digit
@@ -84,7 +87,7 @@ where getNatural : List (Fin 10) -> Nat
 
 naturalLit : Parser (Expr ImportStatement)
 naturalLit = do n <- naturalNumber
-                pure (ENaturalLit n)
+                pure (ENaturalLit initFC n)
 
 -- From lightyear JSON parser
 record Scientific where
@@ -128,16 +131,16 @@ parseScientific = do sign <- optional parseSign
 
 doubleLit : Parser (Expr ImportStatement)
 doubleLit = do k <- map scientificToDouble parseScientific
-               pure (EDoubleLit k)
+               pure (EDoubleLit initFC k)
 
 type : Parser (Expr ImportStatement)
-type = token "Type" *> pure (EConst CType)
+type = token "Type" *> pure (EConst initFC CType)
 
 kind : Parser (Expr ImportStatement)
-kind = token "Kind" *> pure (EConst Kind)
+kind = token "Kind" *> pure (EConst initFC Kind)
 
 sort : Parser (Expr ImportStatement)
-sort = token "Sort" *> pure (EConst Sort)
+sort = token "Sort" *> pure (EConst initFC Sort)
 
 identFirst : Parser Char
 identFirst = letter <|> char '_'
@@ -235,18 +238,18 @@ backticked = do
 varBackticks : Parser (Expr ImportStatement)
 varBackticks = do
   i <- backticked
-  pure $ EVar i 0
+  pure $ EVar initFC i 0
 
 varRegular : Parser (Expr ImportStatement)
 varRegular = do i <- identity
-                pure (EVar i 0)
+                pure (EVar initFC i 0)
 
 varIndexed : Parser (Expr ImportStatement)
 varIndexed = do i <- identity
                 whitespace
                 token "@"
                 n <- naturalNumber
-                pure (EVar i (cast n))
+                pure (EVar initFC i (cast n))
 
 var : Parser (Expr ImportStatement)
 var = varBackticks <|> varIndexed <|> varRegular
@@ -259,14 +262,14 @@ identityDefinition = identity <|> backticked
 
 appl : Parser ((Expr ImportStatement) -> (Expr ImportStatement) -> (Expr ImportStatement))
 appl = do whitespace -- TODO also matches no spaces, but spaces1 messes with the eos parser
-          pure EApp
+          pure $ EApp initFC
 
 projectNames : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
 projectNames = do
   token ".{"
   xs <- (fieldName <* spaces) `sepBy` (token ",")
   token "}"
-  pure (\e => (EProject e (Left (map MkFieldName xs))))
+  pure (\e => (EProject initFC e (Left (map MkFieldName xs))))
 
 dottedList : Parser (List1 FieldName)
 dottedList = do
@@ -277,7 +280,7 @@ field : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
 field = do
   token "."
   ks <- dottedList
-  pure $ (\e' => foldl EField (EField e' (head ks)) (tail ks))
+  pure $ (\e' => foldl (EField initFC) (EField initFC e' (head ks)) (tail ks))
 
 mutual
   projectByType : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
@@ -285,7 +288,7 @@ mutual
     token ".("
     e <- expr
     token ")"
-    pure (\e' => (EProject e' (Right e)))
+    pure (\e' => (EProject initFC e' (Right e)))
 
   -- TODO with is currently right associative and should be left
   withExpr : Parser ((Expr ImportStatement) -> (Expr ImportStatement))
@@ -294,7 +297,7 @@ mutual
     ks <- dottedList
     token "="
     e <- expr
-    pure (\e' => (EWith e' ks e))
+    pure (\e' => (EWith initFC e' ks e))
 
   table : OperatorTable (Expr ImportStatement)
   table = [ [ Postfix projectNames
@@ -303,24 +306,24 @@ mutual
             , Infix appl AssocLeft
             , Postfix withExpr
             ]
-          , [ Infix (do (token "->" <|> token "→") ; pure (EPi "_")) AssocRight ]
-          , [ Infix (do token ":"; pure EAnnot) AssocLeft]
-          , [ Infix (token "&&" $> EBoolAnd) AssocLeft
-            , Infix (token "||" $> EBoolOr) AssocLeft
-            , Infix (token "==" $> EBoolEQ) AssocLeft
-            , Infix (token "!=" $> EBoolNE) AssocLeft
-            , Infix (token "*" $> ENaturalTimes) AssocLeft
-            , Infix (token "++" $> ETextAppend) AssocLeft
+          , [ Infix (do (token "->" <|> token "→") ; pure (EPi initFC "_")) AssocRight ]
+          , [ Infix (do token ":"; pure (EAnnot initFC)) AssocLeft]
+          , [ Infix (token "&&" $> EBoolAnd initFC) AssocLeft
+            , Infix (token "||" $> EBoolOr initFC) AssocLeft
+            , Infix (token "==" $> EBoolEQ initFC) AssocLeft
+            , Infix (token "!=" $> EBoolNE initFC) AssocLeft
+            , Infix (token "*" $> ENaturalTimes initFC) AssocLeft
+            , Infix (token "++" $> ETextAppend initFC) AssocLeft
             ]
-          , [ Infix (token "+" $> ENaturalPlus) AssocLeft]
-          , [ Infix (do (token "===" <|> token "≡"); pure EEquivalent) AssocLeft]
-          , [ Prefix (do token "assert"; token ":"; pure EAssert)]
-          , [ Infix (do token "#"; pure EListAppend) AssocLeft]
-          , [ Infix (pure ECombine <* (token "/\\" <|> token "∧")) AssocLeft
-            , Infix (pure EPrefer <* (token "//" <|> token "⫽")) AssocLeft
-            , Infix (pure ECombineTypes <* (token "//\\\\" <|> token "⩓")) AssocLeft
-            , Infix (pure ERecordCompletion <* (token "::")) AssocLeft
-            , Infix (pure EImportAlt <* (token "?")) AssocLeft
+          , [ Infix (token "+" $> ENaturalPlus initFC) AssocLeft]
+          , [ Infix (do (token "===" <|> token "≡"); pure (EEquivalent initFC)) AssocLeft]
+          , [ Prefix (do token "assert"; token ":"; pure (EAssert initFC))]
+          , [ Infix (do token "#"; pure (EListAppend initFC)) AssocLeft]
+          , [ Infix (pure (ECombine initFC) <* (token "/\\" <|> token "∧")) AssocLeft
+            , Infix (pure (EPrefer initFC) <* (token "//" <|> token "⫽")) AssocLeft
+            , Infix (pure (ECombineTypes initFC) <* (token "//\\\\" <|> token "⩓")) AssocLeft
+            , Infix (pure (ERecordCompletion initFC) <* (token "::")) AssocLeft
+            , Infix (pure (EImportAlt initFC) <* (token "?")) AssocLeft
             ]
           ]
 
@@ -336,14 +339,14 @@ mutual
   recordTypeEmpty = do
     token "{"
     token "}"
-    pure (ERecord (fromList []))
+    pure (ERecord initFC (fromList []))
 
   recordTypeNonEmpty : Parser (Expr ImportStatement)
   recordTypeNonEmpty = do
     token "{"
     xs <- recordTypeElem `sepBy` (token ",")
     token "}"
-    pure (ERecord (fromList xs))
+    pure (ERecord initFC (fromList xs))
 
   recordType : Parser (Expr ImportStatement)
   recordType = do
@@ -361,7 +364,7 @@ mutual
   recordLitPunElem = do
     k <- fieldName
     whitespace
-    pure $ fromList [(MkFieldName k, (EVar k 0))]
+    pure $ fromList [(MkFieldName k, (EVar initFC k 0))]
 
   recordLitDottedElem : Parser (SortedMap FieldName (Expr ImportStatement))
   recordLitDottedElem = do
@@ -373,7 +376,7 @@ mutual
     mkNestedRecord : List1 FieldName -> Expr ImportStatement -> SortedMap FieldName (Expr ImportStatement)
     mkNestedRecord ks e =
       let (k ::: ks') = reverse ks in
-      foldl (\ms,k' => fromList [(k', ERecordLit ms)]) (fromList [(k, e)]) ks'
+      foldl (\ms,k' => fromList [(k', ERecordLit initFC ms)]) (fromList [(k, e)]) ks'
 
   recordLitElem : Parser (SortedMap FieldName (Expr ImportStatement))
   recordLitElem = recordLitDottedElem <|> recordLitRegularElem <|> recordLitPunElem
@@ -383,14 +386,14 @@ mutual
     token "{"
     token "="
     token "}"
-    pure (ERecordLit (fromList []))
+    pure (ERecordLit initFC (fromList []))
 
   recordLitNonEmpty : Parser (Expr ImportStatement)
   recordLitNonEmpty = do
     token "{"
     (x ::: xs) <- recordLitElem `sepBy1` (token ",")
     token "}"
-    pure $ ERecordLit $ foldl (mergeWith ECombine) x xs
+    pure $ ERecordLit initFC $ foldl (mergeWith (ECombine initFC)) x xs
 
   recordLit : Parser (Expr ImportStatement)
   recordLit = do
@@ -419,7 +422,7 @@ mutual
     xs <- unionElem `sepBy` (token "|")
     whitespace
     token ">"
-    pure (EUnion (fromList xs))
+    pure (EUnion initFC (fromList xs))
 
   -- TODO for multi-let the last let MUST have an `in`, the rest are optional.
   -- Need to parse this somehow.
@@ -435,7 +438,7 @@ mutual
     whitespace
     _ <- optional (token "in")
     e <- expr
-    pure (ELet i t v e)
+    pure (ELet initFC i t v e)
 
   piComplex : Parser (Expr ImportStatement)
   piComplex = do
@@ -448,7 +451,7 @@ mutual
     token ")"
     (token "->" <|> token "→")
     ran <- expr
-    pure (EPi i dom ran)
+    pure (EPi initFC i dom ran)
 
   pi : Parser (Expr ImportStatement)
   pi = piComplex
@@ -461,7 +464,7 @@ mutual
     y <- expr
     token "else"
     z <- expr
-    pure (EBoolIf x y z)
+    pure (EBoolIf initFC x y z)
 
   emptyList : Parser (Expr ImportStatement)
   emptyList = do
@@ -469,14 +472,14 @@ mutual
     token "]"
     token ":"
     e <- expr
-    pure (EListLit (Just e) [])
+    pure (EListLit initFC (Just e) [])
 
   populatedList : Parser (Expr ImportStatement)
   populatedList = do
     token "["
     es <- commaSep1' expr
     token "]"
-    pure (EListLit Nothing (forget es))
+    pure (EListLit initFC Nothing (forget es))
 
   annotatedList : Parser (Expr ImportStatement)
   annotatedList = do
@@ -485,7 +488,7 @@ mutual
     token "]"
     token ":"
     e <- expr
-    pure (EListLit (Just e) (forget es))
+    pure (EListLit initFC (Just e) (forget es))
 
   list : Parser (Expr ImportStatement)
   list = emptyList <|> annotatedList <|> populatedList
@@ -561,14 +564,14 @@ mutual
   basicImport : Parser (Expr ImportStatement)
   basicImport = do
     i <- dhallImportStatement
-    pure (EEmbed $ Raw i)
+    pure (EEmbed initFC $ Raw i)
 
   shaImport : Parser (Expr ImportStatement)
   shaImport = do
     i <- dhallImportStatement
     spaces
     sha <- sha
-    pure (EEmbed $ Raw i)
+    pure (EEmbed initFC $ Raw i)
 
   asImport : Parser (Expr ImportStatement)
   asImport = do
@@ -576,7 +579,7 @@ mutual
     spaces
     token "as"
     asType <- importAs
-    pure (EEmbed (asType i))
+    pure (EEmbed initFC (asType i))
 
   shaAndAsImport : Parser (Expr ImportStatement)
   shaAndAsImport = do
@@ -586,7 +589,7 @@ mutual
     spaces
     token "as"
     asType <- importAs
-    pure (EEmbed (asType i))
+    pure (EEmbed initFC (asType i))
 
   dhallImport : Parser (Expr ImportStatement)
   dhallImport = shaAndAsImport <|> asImport <|> shaImport <|> basicImport
@@ -603,36 +606,36 @@ mutual
     token ")"
     (token "->" <|> token "→")
     e <- expr
-    pure (ELam i ty e)
+    pure (ELam initFC i ty e)
 
   esome : Parser (Expr ImportStatement)
   esome = do
     token "Some"
     e <- expr
-    pure (ESome e)
+    pure (ESome initFC e)
 
   mergeExpr : Parser (Expr ImportStatement)
   mergeExpr = do
     token "merge"
     x <- expr
     case x of -- TODO hacky
-         (EApp y z) => pure (EMerge y z Nothing)
-         (EAnnot (EApp y z) t) => pure (EMerge y z (Just t))
+         (EApp fc y z) => pure (EMerge fc y z Nothing)
+         (EAnnot fc (EApp _ y z) t) => pure (EMerge fc y z (Just t))
          _ => do whitespace
                  y <- expr
                  whitespace
                  t <- optional (token ":" *> term)
                  case y of
-                      (EAnnot y' a) => pure (EMerge x y' (Just a))
-                      _ => pure (EMerge x y t)
+                      (EAnnot fc y' a) => pure (EMerge fc x y' (Just a))
+                      _ => pure (EMerge initFC x y t)
 
   toMap : Parser (Expr ImportStatement)
   toMap = do
     token "toMap"
     x <- expr
     case x of -- TODO hacky
-         (EAnnot x y) => pure (EToMap x (Just y))
-         x => pure (EToMap x Nothing)
+         (EAnnot fc x y) => pure (EToMap fc x (Just y))
+         x => pure (EToMap initFC x Nothing)
 
   term : Parser (Expr ImportStatement)
   term = do
@@ -777,7 +780,7 @@ mutual
   textLiteral : Parser (Expr ImportStatement)
   textLiteral = (do
             literal <- doubleQuotedLiteral <|> singleQuoteLiteral
-            pure (ETextLit literal) ) <?> "literal"
+            pure (ETextLit initFC literal) ) <?> "literal"
 
   opExpr : Parser (Expr ImportStatement)
   opExpr = buildExpressionParser (Expr ImportStatement) table term

--- a/Idrall/Parser.idr
+++ b/Idrall/Parser.idr
@@ -16,9 +16,6 @@ import Idrall.Path
 
 %hide Prelude.pow
 
-initFC : FC
-initFC = EmptyFC
-
 builtin : Parser (Expr ImportStatement)
 builtin =
   (string "Natural/build" *> pure (ENaturalBuild initFC)) <|>

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -243,6 +243,9 @@ mutual
     <|> match (exact "}") Symbol
     <|> match (exact "[") Symbol
     <|> match (exact "]") Symbol
+    <|> match (exact "<") Symbol
+    <|> match (exact ">") Symbol
+    <|> match (exact "|") Symbol
     <|> match (exact ",") Symbol
     <|> match (exact ".") Symbol
     <|> match (exact "as Text") Keyword

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -126,7 +126,7 @@ doubleLit : Lexer
 doubleLit
     = (opt sign)
       <+> ((digits <+> is '.' <+> digits <+> opt exponent)
-           <|> (digits <+> opt exponent))
+           <|> (digits <+> exponent))
 
 -- comments
 mutual

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -224,6 +224,7 @@ mutual
     <|> embed
     <|> match (exact "||") Symbol
     <|> match (exact "&&") Symbol
+    <|> match (exact "===") Symbol
     <|> match (exact "==") Symbol
     <|> match (exact "!=") Symbol
     <|> match (exact "=") Symbol

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -84,8 +84,7 @@ builtins =
   , "List/build", "List/fold", "List/length", "List/head"
   , "List/last", "List/indexed", "List/reverse", "List"
   , "Text", "Text/show", "Text/replace"
-  , "None"
-  , "Optional"
+  , "Optional", "Some", "None"
   , "NaN"
   ]
 

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -74,17 +74,20 @@ TokenRawToken = RawToken
 
 export
 builtins : List String
-builtins = ["True", "False",
-  "Natural/build", "Natural/fold", "Natural/isZero", "Natural/even",
-  "Natural/odd", "Natural/subtract", "Natural/toInteger", "Natural/show",
-  "Integer/show", "Integer/negate", "Integer/clamp", "Integer/toDouble",
-  "Double/show",
-  "List/build", "List/fold", "List/length", "List/head",
-  "List/last", "List/indexed", "List/reverse", "List",
-  "Text/show", "Text/replace",
-  "None",
-  "Optional",
-  "NaN"]
+builtins =
+  [ "Type", "Kind", "Sort"
+  , "Bool", "True", "False"
+  , "Natural", "Natural/build", "Natural/fold", "Natural/isZero", "Natural/even"
+  , "Natural/odd", "Natural/subtract", "Natural/toInteger", "Natural/show"
+  , "Integer", "Integer/show", "Integer/negate", "Integer/clamp", "Integer/toDouble"
+  , "Double", "Double/show"
+  , "List/build", "List/fold", "List/length", "List/head"
+  , "List/last", "List/indexed", "List/reverse", "List"
+  , "Text", "Text/show", "Text/replace"
+  , "None"
+  , "Optional"
+  , "NaN"
+  ]
 
 export
 keywords : List String

--- a/Idrall/Parser/Lexer.idr
+++ b/Idrall/Parser/Lexer.idr
@@ -88,7 +88,10 @@ builtins = ["True", "False",
 
 export
 keywords : List String
-keywords = ["let", "in", "with"]
+keywords = ["let", "in", "with",
+  "if", "then", "else",
+  "merge", "toMap", "missing",
+  "using", "assert"]
 
 -- variables
 ident : Lexer
@@ -212,10 +215,25 @@ mutual
   rawTokens : Tokenizer RawToken
   rawTokens =
     match blockComment Comment
+    <|> match (exact "//\\\\") Symbol
+    <|> match (exact "//") Symbol
+    <|> match (exact "/\\") Symbol
+    <|> match (exact "\\") Symbol
     <|> embed
-    <|> match (exact "=") Symbol
+    <|> match (exact "||") Symbol
     <|> match (exact "&&") Symbol
+    <|> match (exact "==") Symbol
+    <|> match (exact "!=") Symbol
+    <|> match (exact "=") Symbol
     <|> match (exact "->") Symbol
+    <|> match (exact "++") Symbol
+    <|> match (exact "+") Symbol
+    <|> match (exact "*") Symbol
+    <|> match (exact "#") Symbol
+    <|> match (exact "::") Symbol
+    <|> match (exact ":") Symbol
+    <|> match (exact "?") Symbol
+    <|> match (exact "`") Symbol
     <|> match (exact "(") Symbol
     <|> match (exact ")") Symbol
     <|> match (exact "{") Symbol
@@ -224,6 +242,7 @@ mutual
     <|> match (exact "]") Symbol
     <|> match (exact ",") Symbol
     <|> match (exact ".") Symbol
+    <|> match (exact "as Text") Keyword
     <|> match space (const White)
     <|> match doubleLit (TDouble . cast)
     <|> match ident parseIdent

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -28,6 +28,13 @@ whitespace =
       _ => Nothing
 
 export
+tokenW : Grammar state (TokenRawToken) True a -> Grammar state (TokenRawToken) True a
+tokenW p = do
+  x <- p
+  _ <- optional whitespace
+  pure x
+
+export
 keyword : String -> Rule ()
 keyword req =
   terminal ("Expected '" ++ req ++ "'") $
@@ -103,8 +110,8 @@ doubleLit =
 export
 dottedList : Rule (List1 String)
 dottedList = do
-  -- x <- sepBy1 (match $ Symbol ".") (identPart)
-  x <- sepBy1 (symbol ".") (identPart)
+  _ <- optional whitespace
+  x <- sepBy1 (tokenW $ symbol ".") (identPart)
   pure x
 
 export

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -116,6 +116,14 @@ builtin =
       _ => Nothing
 
 export
+someBuiltin : Rule ()
+someBuiltin =
+  terminal "expected builtin" $
+    \case
+      Builtin "Some" => Just ()
+      _ => Nothing
+
+export
 endOfInput : Rule ()
 endOfInput =
   terminal "expected builtin" $

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -114,3 +114,11 @@ builtin =
     \case
       Builtin x => Just x
       _ => Nothing
+
+export
+endOfInput : Rule ()
+endOfInput =
+  terminal "expected builtin" $
+    \case
+      EndInput => Just ()
+      _ => Nothing

--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -100,6 +100,22 @@ embedPath =
       _ => Nothing
 
 export
+naturalLit : Rule Nat
+naturalLit =
+  terminal "expected natural" $
+    \case
+      TNatural x => Just x
+      _ => Nothing
+
+export
+integerLit : Rule Integer
+integerLit =
+  terminal "expected integer" $
+    \case
+      TInteger x => Just x
+      _ => Nothing
+
+export
 doubleLit : Rule Double
 doubleLit =
   terminal "expected double" $

--- a/Idrall/ParserNew.idr
+++ b/Idrall/ParserNew.idr
@@ -159,7 +159,7 @@ mutual
     | EField FC (Expr a) String -- | EField (Expr a) FieldName
     -- | EProject (Expr a) (Either (List FieldName) (Expr a))
     | EWith FC (Expr a) (List1 String) (Expr a) -- | EWith (Expr a) (List1 FieldName) (Expr a)
-    -- | EImportAlt (Expr a) (Expr a)
+    | EImportAlt FC (Expr a) (Expr a) -- | EImportAlt (Expr a) (Expr a)
     | EEmbed FC String -- | EEmbed (Import a)
 
 mkExprFC : OriginDesc -> WithBounds x -> (FC -> x -> Expr a) -> Expr a
@@ -233,6 +233,7 @@ getBounds (EMerge fc _ _ _) = fc
 getBounds (EToMap fc _ _) = fc
 getBounds (EField fc _ _) = fc
 getBounds (EWith fc _ _ _) = fc
+getBounds (EImportAlt fc _ _) = fc
 getBounds (EEmbed fc _) = fc
 
 updateBounds : FC -> Expr a -> Expr a
@@ -300,6 +301,7 @@ updateBounds fc (EPrefer _ x y) = EPrefer fc x y
 updateBounds fc (ERecordCompletion _ x y) = ERecordCompletion fc x y
 updateBounds fc (EMerge _ x y z) = EMerge fc x y z
 updateBounds fc (EToMap _ x y) = EToMap fc x y
+updateBounds fc (EImportAlt _ x y) = EImportAlt fc x y
 updateBounds fc (EEmbed _ z) = EEmbed fc z
 
 public export
@@ -381,6 +383,7 @@ mutual
     show (ERecordCompletion fc x y) = "(\{show fc}:ERecordCompletion \{show x} \{show y}"
     show (EMerge fc x y z) = "(\{show fc}:EMerge \{show x} \{show y} \{show z}"
     show (EToMap fc x y) = "(\{show fc}:EToMap \{show x} \{show y}"
+    show (EImportAlt fc x y) = "(\{show fc}:EImportAlt \{show fc} \{show x} \{show y})"
     show (EEmbed fc x) = "(\{show fc}:EEmbed \{show fc} \{show x})"
 
 prettyDottedList : List String -> Doc ann
@@ -501,6 +504,7 @@ mutual
     pretty (EToMap fc x (Just y)) =
       pretty "merge" <++> pretty x
       <++> pretty ":" <++> pretty y
+    pretty (EImportAlt fc x y) = pretty x <++> pretty "?" <++> pretty y
     pretty (EEmbed fc x) = pretty x
 
 public export
@@ -743,7 +747,7 @@ mutual
     (opParser "++" ETextAppend) <|> (opParser "#" EListAppend)
       <|> (opParser "/\\" ECombine) <|> (opParser "//\\\\" ECombineTypes)
       <|> (opParser "//" EPrefer) <|> (opParser "::" ERecordCompletion)
-      <|> (opParser "===" EEquivalent)
+      <|> (opParser "===" EEquivalent) <|> (opParser "?" EImportAlt)
 
   plusOp : FC -> Grammar state (TokenRawToken) True (Expr () -> Expr () -> Expr ())
   plusOp fc = (opParser "+" ENaturalPlus)

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -69,195 +69,195 @@ mutual
   export
   covering
   resolve : (history : List FilePath) -> Maybe FilePath -> Expr ImportStatement -> IOEither Error (Expr Void)
-  resolve h p (EVar x i) = pure (EVar x i)
-  resolve h p (EConst x) = pure (EConst x)
-  resolve h p (EPi x y z) = do
+  resolve h p (EVar fc x i) = pure (EVar fc x i)
+  resolve h p (EConst fc x) = pure (EConst fc x)
+  resolve h p (EPi fc x y z) = do
     y' <- resolve h p y
     z' <- resolve h p z
-    pure (EPi x y' z')
-  resolve h p (ELam x y z) = do
+    pure (EPi fc x y' z')
+  resolve h p (ELam fc x y z) = do
     y' <- resolve h p y
     z' <- resolve h p z
-    pure (ELam x y' z')
-  resolve h p (EApp x y) = do
+    pure (ELam fc x y' z')
+  resolve h p (EApp fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EApp x' y')
-  resolve h p (ELet x Nothing z w) = do
-    z' <- resolve h p z
-    w' <- resolve h p w
-    pure (ELet x Nothing z' w')
-  resolve h p (ELet x (Just y) z w) = do
-    y' <- resolve h p y
+    pure (EApp fc x' y')
+  resolve h p (ELet fc x Nothing z w) = do
     z' <- resolve h p z
     w' <- resolve h p w
-    pure (ELet x (Just y') z' w')
-  resolve h p (EAnnot x y) = do
+    pure (ELet fc x Nothing z' w')
+  resolve h p (ELet fc x (Just y) z w) = do
+    y' <- resolve h p y
+    z' <- resolve h p z
+    w' <- resolve h p w
+    pure (ELet fc x (Just y') z' w')
+  resolve h p (EAnnot fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EAnnot x' y')
-  resolve h p (EEquivalent x y) = do
+    pure (EAnnot fc x' y')
+  resolve h p (EEquivalent fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EEquivalent x' y')
-  resolve h p (EAssert x) = do
+    pure (EEquivalent fc x' y')
+  resolve h p (EAssert fc x) = do
     x' <- resolve h p x
-    pure (EAssert x')
-  resolve h p EBool = pure EBool
-  resolve h p (EBoolLit x) = pure (EBoolLit x)
-  resolve h p (EBoolAnd x y) = do
-    x' <- resolve h p x
-    y' <- resolve h p y
-    pure (EBoolAnd x' y')
-  resolve h p (EBoolOr x y) = do
+    pure (EAssert fc x')
+  resolve h p EBool fc = pure EBool fc
+  resolve h p (EBoolLit fc x) = pure (EBoolLit fc x)
+  resolve h p (EBoolAnd fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EBoolOr x' y')
-  resolve h p (EBoolEQ x y) = do
+    pure (EBoolAnd fc x' y')
+  resolve h p (EBoolOr fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EBoolEQ x' y')
-  resolve h p (EBoolNE x y) = do
+    pure (EBoolOr fc x' y')
+  resolve h p (EBoolEQ fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EBoolNE x' y')
-  resolve h p (EBoolIf x y z) = do
+    pure (EBoolEQ fc x' y')
+  resolve h p (EBoolNE fc x y) = do
+    x' <- resolve h p x
+    y' <- resolve h p y
+    pure (EBoolNE fc x' y')
+  resolve h p (EBoolIf fc x y z) = do
     x' <- resolve h p x
     y' <- resolve h p y
     z' <- resolve h p z
-    pure (EBoolIf x' y' z')
-  resolve h p ENatural = pure ENatural
-  resolve h p (ENaturalLit k) = pure (ENaturalLit k)
-  resolve h p ENaturalBuild = pure ENaturalBuild
-  resolve h p ENaturalFold = pure ENaturalFold
-  resolve h p ENaturalIsZero = pure ENaturalIsZero
-  resolve h p ENaturalEven = pure ENaturalEven
-  resolve h p ENaturalOdd = pure ENaturalOdd
-  resolve h p ENaturalSubtract = pure ENaturalSubtract
-  resolve h p ENaturalToInteger = pure ENaturalToInteger
-  resolve h p ENaturalShow = pure ENaturalShow
-  resolve h p (ENaturalPlus x y) = do
+    pure (EBoolIf fc x' y' z')
+  resolve h p (ENatural fc) = pure $ ENatural fc
+  resolve h p (ENaturalLit fc k) = pure $ ENaturalLit fc k
+  resolve h p (ENaturalBuild fc) = pure $ ENaturalBuild fc
+  resolve h p (ENaturalFold fc) = pure $ ENaturalFold fc
+  resolve h p (ENaturalIsZero fc) = pure $ ENaturalIsZero fc
+  resolve h p (ENaturalEven fc) = pure $ ENaturalEven fc
+  resolve h p (ENaturalOdd fc) = pure $ ENaturalOdd fc
+  resolve h p (ENaturalSubtract fc) = pure $ ENaturalSubtract fc
+  resolve h p (ENaturalToInteger fc) = pure $ ENaturalToInteger fc
+  resolve h p (ENaturalShow fc) = pure $ ENaturalShow fc
+  resolve h p (ENaturalPlus fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ENaturalPlus x' y')
-  resolve h p (ENaturalTimes x y) = do
+    pure (ENaturalPlus fc x' y')
+  resolve h p (ENaturalTimes fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ENaturalTimes x' y')
-  resolve h p EInteger = pure EInteger
-  resolve h p (EIntegerLit k) = pure (EIntegerLit k)
-  resolve h p EIntegerShow = pure EIntegerShow
-  resolve h p EIntegerClamp = pure EIntegerClamp
-  resolve h p EIntegerNegate = pure EIntegerNegate
-  resolve h p EIntegerToDouble = pure EIntegerToDouble
-  resolve h p EDouble = pure EDouble
-  resolve h p (EDoubleLit k) = pure (EDoubleLit k)
-  resolve h p EDoubleShow = pure EDoubleShow
-  resolve h p EList = pure EList
-  resolve h p (EListLit Nothing xs) = do
+    pure (ENaturalTimes fc x' y')
+  resolve h p (EInteger fc) = pure $ EInteger fc
+  resolve h p (EIntegerLit k) = pure $ EIntegerLit k
+  resolve h p (EIntegerShow fc) = pure $ EIntegerShow fc
+  resolve h p (EIntegerClamp fc) = pure $ EIntegerClamp fc
+  resolve h p (EIntegerNegate fc) = pure $ EIntegerNegate fc
+  resolve h p (EIntegerToDouble fc) = pure $ EIntegerToDouble fc
+  resolve h p (EDouble fc) = pure $ EDouble fc
+  resolve h p (EDoubleLit fc k) = pure $ EDoubleLit k
+  resolve h p (EDoubleShow fc) = pure $ EDoubleShow fc
+  resolve h p (EList fc) = pure $ EList fc
+  resolve h p (EListLit fc Nothing xs) = do
     xs' <- resolveList h p xs
-    pure (EListLit Nothing xs')
-  resolve h p (EListLit (Just x) xs) = do
+    pure (EListLit fc Nothing xs')
+  resolve h p (EListLit fc (Just x) xs) = do
     x' <- resolve h p x
     xs' <- resolveList h p xs
-    pure (EListLit (Just x') xs')
-  resolve h p (EListAppend x y) = do
+    pure (EListLit fc (Just x') xs')
+  resolve h p (EListAppend fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EListAppend x' y')
-  resolve h p EListBuild = pure EListBuild
-  resolve h p EListFold = pure EListFold
-  resolve h p EListLength = pure EListLength
-  resolve h p EListHead = pure EListHead
-  resolve h p EListLast = pure EListLast
-  resolve h p EListIndexed = pure EListIndexed
-  resolve h p EListReverse = pure EListReverse
-  resolve h p EText = pure EText
-  resolve h p (ETextLit (MkChunks xs x)) = do
+    pure (EListAppend fc x' y')
+  resolve h p (EListBuild fc) = pure $ EListBuild fc
+  resolve h p (EListFold fc) = pure $ EListFold fc
+  resolve h p (EListLength fc) = pure $ EListLength fc
+  resolve h p (EListHead fc) = pure $ EListHead fc
+  resolve h p (EListLast fc) = pure $ EListLast fc
+  resolve h p (EListIndexed fc) = pure $ EListIndexed fc
+  resolve h p (EListReverse fc) = pure $ EListReverse fc
+  resolve h p (EText fc) = pure $ EText fc
+  resolve h p (ETextLit fc (MkChunks xs x)) = do
     xs' <- resolveChunks h p xs
-    pure (ETextLit (MkChunks xs' x))
-  resolve h p (ETextAppend x y) = do
+    pure (ETextLit fc (MkChunks xs' x))
+  resolve h p (ETextAppend fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ETextAppend x' y')
-  resolve h p ETextShow = pure ETextShow
-  resolve h p ETextReplace = pure ETextReplace
-  resolve h p EOptional = pure EOptional
-  resolve h p ENone = pure ENone
-  resolve h p (ESome x) = do
+    pure (ETextAppend fc x' y')
+  resolve h p (ETextShow fc) = pure $ ETextShow fc
+  resolve h p (ETextReplace fc) = pure $ ETextReplace fc
+  resolve h p (EOptional fc) = pure $ EOptional fc
+  resolve h p (ENone fc) = pure $ ENone fc
+  resolve h p (ESome fc x) = do
     x' <- resolve h p x
-    pure (ESome x')
-  resolve h p (ERecord x) =
+    pure (ESome fc x')
+  resolve h p (ERecord fc x) =
     let kv = toList x in do
       kv' <- resolveRecord h p kv
-      pure (ERecord (fromList kv'))
-  resolve h p (ERecordLit x) =
+      pure (ERecord fc (fromList kv'))
+  resolve h p (ERecordLit fc x) =
     let kv = toList x in do
       kv' <- resolveRecord h p kv
-      pure (ERecordLit (fromList kv'))
-  resolve h p (ECombine x y) = do
+      pure (ERecordLit fc (fromList kv'))
+  resolve h p (ECombine fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ECombine x' y')
-  resolve h p (ECombineTypes x y) = do
+    pure (ECombine fc x' y')
+  resolve h p (ECombineTypes fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ECombineTypes x' y')
-  resolve h p (EPrefer x y) = do
+    pure (ECombineTypes fc x' y')
+  resolve h p (EPrefer fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EPrefer x' y')
-  resolve h p (ERecordCompletion x y) = do
+    pure (EPrefer fc x' y')
+  resolve h p (ERecordCompletion fc x y) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (ERecordCompletion x' y')
-  resolve h p (EMerge x y Nothing) = do
+    pure (ERecordCompletion fc x' y')
+  resolve h p (EMerge fc x y Nothing) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EMerge x' y' Nothing)
-  resolve h p (EMerge x y (Just z)) = do
+    pure (EMerge fc x' y' Nothing)
+  resolve h p (EMerge fc x y (Just z)) = do
     x' <- resolve h p x
     y' <- resolve h p y
     z' <- resolve h p z
-    pure (EMerge x' y' (Just z'))
-  resolve h p (EUnion x) =
+    pure (EMerge fc x' y' (Just z'))
+  resolve h p (EUnion fc x) =
     let kv = toList x in do
       kv' <- resolveUnion h p kv
-      pure (EUnion (fromList kv'))
-  resolve h p (EToMap x Nothing) = do
+      pure (EUnion fc (fromList kv'))
+  resolve h p (EToMap fc x Nothing) = do
     x' <- resolve h p x
-    pure (EToMap x' Nothing)
-  resolve h p (EToMap x (Just y)) = do
-    x' <- resolve h p x
-    y' <- resolve h p y
-    pure (EToMap x' (Just y'))
-  resolve h p (EField x y) = do
-    pure (EField !(resolve h p x) y)
-  resolve h p (EProject x (Left y)) = do
-    x' <- resolve h p x
-    pure (EProject x' (Left y))
-  resolve h p (EProject x (Right y)) = do
+    pure (EToMap fc x' Nothing)
+  resolve h p (EToMap fc x (Just y)) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EProject x' (Right y'))
-  resolve h p (EWith x ks y) = do
+    pure (EToMap fc x' (Just y'))
+  resolve h p (EField fc x y) = do
+    pure (EField fc !(resolve h p x) y)
+  resolve h p (EProject fc x (Left y)) = do
+    x' <- resolve h p x
+    pure (EProject fc x' (Left y))
+  resolve h p (EProject fc x (Right y)) = do
     x' <- resolve h p x
     y' <- resolve h p y
-    pure (EWith x' ks y')
-  resolve h p (EImportAlt x y) =
+    pure (EProject fc x' (Right y'))
+  resolve h p (EWith fc x ks y) = do
+    x' <- resolve h p x
+    y' <- resolve h p y
+    pure (EWith fc x' ks y')
+  resolve h p (EImportAlt fc x y) =
     case resolve h p x of
          (MkIOEither x') => MkIOEither $ do
            case !x' of
                 (Right x'') => pure $ Right x''
                 (Left w) => case resolve h p y of
                                  (MkIOEither y'') => y''
-  resolve h p (EEmbed (Raw (LocalFile x))) = resolveLocalFile h p x
-  resolve h p (EEmbed (Raw (EnvVar x))) = resolveEnvVar h p x
-  resolve h p (EEmbed (Raw (Http x))) = MkIOEither (pure (Left (ErrorMessage "TODO http imports not implemented")))
-  resolve h p (EEmbed (Raw Missing)) = MkIOEither (pure (Left (ErrorMessage "No valid imports")))
-  resolve h p (EEmbed (Text a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Text not implemented")))
-  resolve h p (EEmbed (Location a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Location not implemented")))
-  resolve h p (EEmbed (Resolved x)) = MkIOEither (pure (Left (ErrorMessage "Already resolved")))
+  resolve h p (EEmbed fc (Raw (LocalFile x))) = resolveLocalFile h p x
+  resolve h p (EEmbed fc (Raw (EnvVar x))) = resolveEnvVar h p x
+  resolve h p (EEmbed fc (Raw (Http x))) = MkIOEither (pure (Left (ErrorMessage "TODO http imports not implemented")))
+  resolve h p (EEmbed fc (Raw Missing)) = MkIOEither (pure (Left (ErrorMessage "No valid imports")))
+  resolve h p (EEmbed fc (Text a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Text not implemented")))
+  resolve h p (EEmbed fc (Location a)) = MkIOEither (pure (Left (ErrorMessage "TODO as Location not implemented")))
+  resolve h p (EEmbed fc (Resolved x)) = MkIOEither (pure (Left (ErrorMessage "Already resolved")))
 
   resolveRecord :  (history : List FilePath)
                -> Maybe FilePath

--- a/Idrall/Resolve.idr
+++ b/Idrall/Resolve.idr
@@ -103,7 +103,7 @@ mutual
   resolve h p (EAssert fc x) = do
     x' <- resolve h p x
     pure (EAssert fc x')
-  resolve h p EBool fc = pure EBool fc
+  resolve h p (EBool fc) = pure $ EBool fc
   resolve h p (EBoolLit fc x) = pure (EBoolLit fc x)
   resolve h p (EBoolAnd fc x y) = do
     x' <- resolve h p x
@@ -145,13 +145,13 @@ mutual
     y' <- resolve h p y
     pure (ENaturalTimes fc x' y')
   resolve h p (EInteger fc) = pure $ EInteger fc
-  resolve h p (EIntegerLit k) = pure $ EIntegerLit k
+  resolve h p (EIntegerLit fc k) = pure $ EIntegerLit fc k
   resolve h p (EIntegerShow fc) = pure $ EIntegerShow fc
   resolve h p (EIntegerClamp fc) = pure $ EIntegerClamp fc
   resolve h p (EIntegerNegate fc) = pure $ EIntegerNegate fc
   resolve h p (EIntegerToDouble fc) = pure $ EIntegerToDouble fc
   resolve h p (EDouble fc) = pure $ EDouble fc
-  resolve h p (EDoubleLit fc k) = pure $ EDoubleLit k
+  resolve h p (EDoubleLit fc k) = pure $ EDoubleLit fc k
   resolve h p (EDoubleShow fc) = pure $ EDoubleShow fc
   resolve h p (EList fc) = pure $ EList fc
   resolve h p (EListLit fc Nothing xs) = do

--- a/Idrall/Value.idr
+++ b/Idrall/Value.idr
@@ -13,84 +13,84 @@ mutual
   -- Values
   public export
   data Value
-    = VConst U
-    | VVar Name Int
-    | VPrimVar
-    | VApp Value Value
-    | VLambda Ty Closure
-    | VHLam HLamInfo (Value -> Either Error Value)
-    | VPi Ty Closure
-    | VHPi Name Value (Value -> Either Error Value)
+    = VConst FC U
+    | VVar FC Name Int
+    | VPrimVar FC
+    | VApp FC Value Value
+    | VLambda FC Ty Closure
+    | VHLam FC HLamInfo (Value -> Either Error Value)
+    | VPi FC Ty Closure
+    | VHPi FC Name Value (Value -> Either Error Value)
 
-    | VBool
-    | VBoolLit Bool
-    | VBoolAnd Value Value
-    | VBoolOr Value Value
-    | VBoolEQ Value Value
-    | VBoolNE Value Value
-    | VBoolIf Value Value Value
+    | VBool FC
+    | VBoolLit FC Bool
+    | VBoolAnd FC Value Value
+    | VBoolOr FC Value Value
+    | VBoolEQ FC Value Value
+    | VBoolNE FC Value Value
+    | VBoolIf FC Value Value Value
 
-    | VNatural
-    | VNaturalLit Nat
-    | VNaturalBuild Value
-    | VNaturalFold Value Value Value Value
-    | VNaturalIsZero Value
-    | VNaturalEven Value
-    | VNaturalOdd Value
-    | VNaturalSubtract Value Value
-    | VNaturalShow Value
-    | VNaturalToInteger Value
-    | VNaturalPlus Value Value
-    | VNaturalTimes Value Value
+    | VNatural FC
+    | VNaturalLit FC Nat
+    | VNaturalBuild FC Value
+    | VNaturalFold FC Value Value Value Value
+    | VNaturalIsZero FC Value
+    | VNaturalEven FC Value
+    | VNaturalOdd FC Value
+    | VNaturalSubtract FC Value Value
+    | VNaturalShow FC Value
+    | VNaturalToInteger FC Value
+    | VNaturalPlus FC Value Value
+    | VNaturalTimes FC Value Value
 
-    | VInteger
-    | VIntegerLit Integer
-    | VIntegerShow Value
-    | VIntegerNegate Value
-    | VIntegerClamp Value
-    | VIntegerToDouble Value
+    | VInteger FC
+    | VIntegerLit FC Integer
+    | VIntegerShow FC Value
+    | VIntegerNegate FC Value
+    | VIntegerClamp FC Value
+    | VIntegerToDouble FC Value
 
-    | VDouble
-    | VDoubleLit Double
-    | VDoubleShow Value
+    | VDouble FC
+    | VDoubleLit FC Double
+    | VDoubleShow FC Value
 
-    | VText
-    | VTextLit VChunks
-    | VTextAppend Value Value
-    | VTextShow Value
-    | VTextReplace Value Value Value
+    | VText FC
+    | VTextLit FC VChunks
+    | VTextAppend FC Value Value
+    | VTextShow FC Value
+    | VTextReplace FC Value Value Value
 
-    | VList Ty
-    | VListLit (Maybe Ty) (List Value)
-    | VListAppend Value Value
-    | VListBuild Value Value
-    | VListFold Value Value Value Value Value
-    | VListLength Value Value
-    | VListHead Value Value
-    | VListLast Value Value
-    | VListIndexed Value Value
-    | VListReverse Value Value
+    | VList FC Ty
+    | VListLit FC (Maybe Ty) (List Value)
+    | VListAppend FC Value Value
+    | VListBuild FC Value Value
+    | VListFold FC Value Value Value Value Value
+    | VListLength FC Value Value
+    | VListHead FC Value Value
+    | VListLast FC Value Value
+    | VListIndexed FC Value Value
+    | VListReverse FC Value Value
 
-    | VOptional Ty
-    | VNone Ty
-    | VSome Ty
+    | VOptional FC Ty
+    | VNone FC Ty
+    | VSome FC Ty
 
-    | VEquivalent Value Value
-    | VAssert Value
+    | VEquivalent FC Value Value
+    | VAssert FC Value
 
-    | VRecord (SortedMap FieldName Value)
-    | VRecordLit (SortedMap FieldName Value)
-    | VUnion (SortedMap FieldName (Maybe Value))
-    | VField Value FieldName
-    | VCombine Value Value
-    | VCombineTypes Value Value
-    | VPrefer Value Value
-    | VMerge Value Value (Maybe Value)
-    | VToMap Value (Maybe Value)
+    | VRecord FC (SortedMap FieldName Value)
+    | VRecordLit FC (SortedMap FieldName Value)
+    | VUnion FC (SortedMap FieldName (Maybe Value))
+    | VField FC Value FieldName
+    | VCombine FC Value Value
+    | VCombineTypes FC Value Value
+    | VPrefer FC Value Value
+    | VMerge FC Value Value (Maybe Value)
+    | VToMap FC Value (Maybe Value)
     -- TODO missing VField?
-    | VInject (SortedMap FieldName (Maybe Value)) FieldName (Maybe Value) -- TODO proof that key is in SM?
-    | VProject (Value) (Either (List FieldName) (Value))
-    | VWith Value (List1 FieldName) Value
+    | VInject FC (SortedMap FieldName (Maybe Value)) FieldName (Maybe Value) -- TODO proof that key is in SM?
+    | VProject FC (Value) (Either (List FieldName) (Value))
+    | VWith FC Value (List1 FieldName) Value
 
   public export
   data Env
@@ -118,12 +118,12 @@ mutual
 ||| Non-dependent function arrow
 public export
 vFun : Value -> Value -> Value
-vFun a b = VHPi "_" a (\_ => Right b)
+vFun a b = VHPi initFC "_" a (\_ => Right b)
 
 ||| Returns `VHLam Prim f`
 public export
 VPrim : (Value -> Either Error Value) -> Value
-VPrim f = VHLam Prim f
+VPrim f = VHLam initFC Prim f
 
 mutual
   Show HLamInfo where
@@ -148,85 +148,85 @@ mutual
 
   public export
   Show Value where
-    show (VConst x) = "(VConst " ++ show x ++ ")"
-    show (VVar x i) = "(VVar " ++ show x ++ " " ++ show i ++ ")"
-    show (VPrimVar) = "VPrimVar"
-    show (VApp x y) = "(VApp " ++ show x ++ " " ++ show y ++ ")"
-    show (VLambda x y) = "(VLambda " ++ show x ++ " " ++ show y ++ ")"
-    show (VHLam i x) = "(VHLam " ++ show i ++ " " ++ show (x VPrimVar)
-    show (VPi x y) = "(VPi " ++ show x ++ " " ++ show y ++ ")"
-    show (VHPi i x y) = "(VHPi " ++ show i ++ " " ++ show x ++ show (y VPrimVar)
+    show (VConst fc x) = "(VConst " ++ show x ++ ")"
+    show (VVar fc x i) = "(VVar " ++ show x ++ " " ++ show i ++ ")"
+    show (VPrimVar fc) = "VPrimVar"
+    show (VApp fc x y) = "(VApp " ++ show x ++ " " ++ show y ++ ")"
+    show (VLambda fc x y) = "(VLambda " ++ show x ++ " " ++ show y ++ ")"
+    show (VHLam fc i x) = "(VHLam " ++ show i ++ " " ++ show (x (VPrimVar fc))
+    show (VPi fc x y) = "(VPi " ++ show x ++ " " ++ show y ++ ")"
+    show (VHPi fc i x y) = "(VHPi " ++ show i ++ " " ++ show x ++ show (y (VPrimVar fc))
 
-    show VBool = "VBool"
-    show (VBoolLit x) = "(VBoolLit " ++ show x ++ ")"
-    show (VBoolAnd x y) = "(VBoolAnd " ++ show x ++ " " ++ show y ++ ")"
-    show (VBoolOr x y) = "(VBoolOr " ++ show x ++ " " ++ show y ++ ")"
-    show (VBoolEQ x y) = "(VBoolEQ " ++ show x ++ " " ++ show y ++ ")"
-    show (VBoolNE x y) = "(VBoolNE " ++ show x ++ " " ++ show y ++ ")"
-    show (VBoolIf x y z) = "(VBoolNE " ++ show x ++ " " ++ show y ++ " " ++ show y ++ ")"
+    show (VBool fc) = "VBool"
+    show (VBoolLit fc x) = "(VBoolLit " ++ show x ++ ")"
+    show (VBoolAnd fc x y) = "(VBoolAnd " ++ show x ++ " " ++ show y ++ ")"
+    show (VBoolOr fc x y) = "(VBoolOr " ++ show x ++ " " ++ show y ++ ")"
+    show (VBoolEQ fc x y) = "(VBoolEQ " ++ show x ++ " " ++ show y ++ ")"
+    show (VBoolNE fc x y) = "(VBoolNE " ++ show x ++ " " ++ show y ++ ")"
+    show (VBoolIf fc x y z) = "(VBoolNE " ++ show x ++ " " ++ show y ++ " " ++ show y ++ ")"
 
-    show VNatural = "VNatural"
-    show (VNaturalLit k) = "(VNaturalLit " ++ show k ++ ")"
-    show (VNaturalBuild x) = "(VNaturalBuild " ++ show x ++ ")"
-    show (VNaturalFold w x y z) =
+    show (VNatural fc) = "VNatural"
+    show (VNaturalLit fc k) = "(VNaturalLit " ++ show k ++ ")"
+    show (VNaturalBuild fc x) = "(VNaturalBuild " ++ show x ++ ")"
+    show (VNaturalFold fc w x y z) =
       "(VNaturalFold " ++ show w ++ " " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (VNaturalIsZero x) = "(VNaturalIsZero " ++ show x ++ ")"
-    show (VNaturalEven x) = "(VNaturalEven " ++ show x ++ ")"
-    show (VNaturalOdd x) = "(VNaturalOdd " ++ show x ++ ")"
-    show (VNaturalToInteger x) = "(VNaturalToInteger " ++ show x ++ ")"
-    show (VNaturalSubtract x y) = "(VNaturalSubtract " ++ show x ++ " " ++ show y ++ ")"
-    show (VNaturalShow x) = "(VNaturalShow " ++ show x ++ ")"
-    show (VNaturalPlus x y) = "(VNaturalPlus " ++ show x ++ " " ++ show y ++ ")"
-    show (VNaturalTimes x y) = "(VNaturalTimes " ++ show x ++ " " ++ show y ++ ")"
+    show (VNaturalIsZero fc x) = "(VNaturalIsZero " ++ show x ++ ")"
+    show (VNaturalEven fc x) = "(VNaturalEven " ++ show x ++ ")"
+    show (VNaturalOdd fc x) = "(VNaturalOdd " ++ show x ++ ")"
+    show (VNaturalToInteger fc x) = "(VNaturalToInteger " ++ show x ++ ")"
+    show (VNaturalSubtract fc x y) = "(VNaturalSubtract " ++ show x ++ " " ++ show y ++ ")"
+    show (VNaturalShow fc x) = "(VNaturalShow " ++ show x ++ ")"
+    show (VNaturalPlus fc x y) = "(VNaturalPlus " ++ show x ++ " " ++ show y ++ ")"
+    show (VNaturalTimes fc x y) = "(VNaturalTimes " ++ show x ++ " " ++ show y ++ ")"
 
-    show VInteger = "VInteger"
-    show (VIntegerLit x) = "(VIntegerLit " ++ show x ++ ")"
-    show (VIntegerShow x) = "(VIntegerShow " ++ show x ++ ")"
-    show (VIntegerNegate x) = "(VIntegerNegate " ++ show x ++ ")"
-    show (VIntegerClamp x) = "(VIntegerClamp " ++ show x ++ ")"
-    show (VIntegerToDouble x) = "(VIntegerToDouble " ++ show x ++ ")"
+    show (VInteger fc) = "VInteger"
+    show (VIntegerLit fc x) = "(VIntegerLit " ++ show x ++ ")"
+    show (VIntegerShow fc x) = "(VIntegerShow " ++ show x ++ ")"
+    show (VIntegerNegate fc x) = "(VIntegerNegate " ++ show x ++ ")"
+    show (VIntegerClamp fc x) = "(VIntegerClamp " ++ show x ++ ")"
+    show (VIntegerToDouble fc x) = "(VIntegerToDouble " ++ show x ++ ")"
 
-    show VDouble = "VDouble"
-    show (VDoubleLit k) = "(VDoubleLit " ++ show k ++ ")"
-    show (VDoubleShow x) = "(VDoubleShow " ++ show x ++ ")"
+    show (VDouble fc) = "VDouble"
+    show (VDoubleLit fc k) = "(VDoubleLit " ++ show k ++ ")"
+    show (VDoubleShow fc x) = "(VDoubleShow " ++ show x ++ ")"
 
-    show (VText) = "VText"
-    show (VTextLit x) = "(VTextLit " ++ show x ++ ")"
-    show (VTextAppend x y) = "(VTextAppend " ++ show x ++ " " ++ show y ++ ")"
-    show (VTextShow x) = "(VTextShow " ++ show x ++ ")"
-    show (VTextReplace x y z) = "(VTextReplace " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (VText fc) = "VText"
+    show (VTextLit fc x) = "(VTextLit " ++ show x ++ ")"
+    show (VTextAppend fc x y) = "(VTextAppend " ++ show x ++ " " ++ show y ++ ")"
+    show (VTextShow fc x) = "(VTextShow " ++ show x ++ ")"
+    show (VTextReplace fc x y z) = "(VTextReplace " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
 
-    show (VList a) = "(VList " ++ show a ++ ")"
-    show (VListLit ty vs) = "(VListLit " ++ show ty ++ show vs ++ ")"
-    show (VListAppend x y) = "(VListAppend " ++ show x ++ " " ++ show y ++ ")"
-    show (VListBuild x y) = "(VListBuild " ++ show x ++ " " ++ show y ++ ")"
-    show (VListFold v w x y z) =
+    show (VList fc a) = "(VList " ++ show a ++ ")"
+    show (VListLit fc ty vs) = "(VListLit " ++ show ty ++ show vs ++ ")"
+    show (VListAppend fc x y) = "(VListAppend " ++ show x ++ " " ++ show y ++ ")"
+    show (VListBuild fc x y) = "(VListBuild " ++ show x ++ " " ++ show y ++ ")"
+    show (VListFold fc v w x y z) =
       "(VListFold " ++ show v ++ " " ++ show w ++ " " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (VListLength x y) = "(VListLength " ++ show x ++ " " ++ show y ++ ")"
-    show (VListHead x y) = "(VListHead " ++ show x ++ " " ++ show y ++ ")"
-    show (VListLast x y) = "(VListLast " ++ show x ++ " " ++ show y ++ ")"
-    show (VListIndexed x y) = "(VListIndexed " ++ show x ++ " " ++ show y ++ ")"
-    show (VListReverse x y) = "(VListReverse " ++ show x ++ " " ++ show y ++ ")"
+    show (VListLength fc x y) = "(VListLength " ++ show x ++ " " ++ show y ++ ")"
+    show (VListHead fc x y) = "(VListHead " ++ show x ++ " " ++ show y ++ ")"
+    show (VListLast fc x y) = "(VListLast " ++ show x ++ " " ++ show y ++ ")"
+    show (VListIndexed fc x y) = "(VListIndexed " ++ show x ++ " " ++ show y ++ ")"
+    show (VListReverse fc x y) = "(VListReverse " ++ show x ++ " " ++ show y ++ ")"
 
-    show (VOptional a) = "(VOptional " ++ show a ++ ")"
-    show (VNone a) = "(VNone " ++ show a ++ ")"
-    show (VSome a) = "(VSome " ++ show a ++ ")"
+    show (VOptional fc a) = "(VOptional " ++ show a ++ ")"
+    show (VNone fc a) = "(VNone " ++ show a ++ ")"
+    show (VSome fc a) = "(VSome " ++ show a ++ ")"
 
-    show (VEquivalent x y) = "(VEquivalent " ++ show x ++ " " ++ show y ++ ")"
-    show (VAssert x) = "(VAssert " ++ show x ++ ")"
+    show (VEquivalent fc x y) = "(VEquivalent " ++ show x ++ " " ++ show y ++ ")"
+    show (VAssert fc x) = "(VAssert " ++ show x ++ ")"
 
-    show (VRecord a) = "(VRecord $ " ++ show a ++ ")"
-    show (VRecordLit a) = "(VRecordLit $ " ++ show a ++ ")"
-    show (VUnion a) = "(VUnion " ++ show a ++ ")"
-    show (VField x y) = "(VField " ++ show x ++ " " ++ show y ++ ")"
-    show (VCombine x y) = "(VCombine " ++ show x ++ " " ++ show y ++ ")"
-    show (VCombineTypes x y) = "(VCombineTypes " ++ show x ++ " " ++ show y ++ ")"
-    show (VPrefer x y) = "(VPrefer " ++ show x ++ " " ++ show y ++ ")"
-    show (VMerge x y z) = "(VMerge " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
-    show (VToMap x y) = "(VToMap " ++ show x ++ " " ++ show y ++ ")"
-    show (VInject a k v) = "(VInject " ++ show a ++ " " ++ show k ++ " " ++ show v ++ ")"
-    show (VProject x y) = "(VProject " ++ show x ++ " " ++ show y ++ ")"
-    show (VWith x ks y) = "(VWith " ++ show x ++ " " ++ show ks ++ " " ++ show y ++ ")"
+    show (VRecord fc a) = "(VRecord $ " ++ show a ++ ")"
+    show (VRecordLit fc a) = "(VRecordLit $ " ++ show a ++ ")"
+    show (VUnion fc a) = "(VUnion " ++ show a ++ ")"
+    show (VField fc x y) = "(VField " ++ show x ++ " " ++ show y ++ ")"
+    show (VCombine fc x y) = "(VCombine " ++ show x ++ " " ++ show y ++ ")"
+    show (VCombineTypes fc x y) = "(VCombineTypes " ++ show x ++ " " ++ show y ++ ")"
+    show (VPrefer fc x y) = "(VPrefer " ++ show x ++ " " ++ show y ++ ")"
+    show (VMerge fc x y z) = "(VMerge " ++ show x ++ " " ++ show y ++ " " ++ show z ++ ")"
+    show (VToMap fc x y) = "(VToMap " ++ show x ++ " " ++ show y ++ ")"
+    show (VInject fc a k v) = "(VInject " ++ show a ++ " " ++ show k ++ " " ++ show v ++ ")"
+    show (VProject fc x y) = "(VProject " ++ show x ++ " " ++ show y ++ ")"
+    show (VWith fc x ks y) = "(VWith " ++ show x ++ " " ++ show ks ++ " " ++ show y ++ ")"
 
 public export
 Semigroup VChunks where

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ edit-tests: test-setup
 edit-tests-one: test-setup
 	cd ./tests/idrall/idrall004 && rlwrap -n idris2 -p contrib -p test -p idrall One.idr
 
+edit-tests-derive: test-setup
+	cd ./tests/derive/derive001 && rlwrap -n idris2 -p contrib -p test -p idrall Derive.idr
+
 clean:
 	rm -f tests/*.idr~
 	rm -f tests/*.ibc

--- a/tests/derive/derive001/Derive.idr
+++ b/tests/derive/derive001/Derive.idr
@@ -34,16 +34,16 @@ Show ExRec1 where
 
 exRec1 : Maybe ExRec1
 exRec1 = fromDhall
-  (ERecordLit $
-    fromList [ (MkFieldName "mn", ESome $ ENaturalLit 3)
-             , (MkFieldName "n", ENaturalLit 4)
-             , (MkFieldName "i", EIntegerLit 5)
-             , (MkFieldName "b", EBoolLit True)
-             , (MkFieldName "d", EDoubleLit 2.0)
-             , (MkFieldName "lb", EListLit (Just EBool) [EBoolLit True, EBoolLit False])
-             , (MkFieldName "st", (ETextLit (MkChunks [] "hello")))
-             , (MkFieldName "mst", ESome $ (ETextLit (MkChunks [] "hello")))
-             , (MkFieldName "mst2", (EApp ENone EText))
+  (ERecordLit initFC $
+    fromList [ (MkFieldName "mn", ESome initFC $ ENaturalLit initFC 3)
+             , (MkFieldName "n", ENaturalLit initFC 4)
+             , (MkFieldName "i", EIntegerLit initFC 5)
+             , (MkFieldName "b", EBoolLit initFC True)
+             , (MkFieldName "d", EDoubleLit initFC 2.0)
+             , (MkFieldName "lb", EListLit initFC (Just $ EBool initFC) [EBoolLit initFC True, EBoolLit initFC False])
+             , (MkFieldName "st", (ETextLit initFC (MkChunks [] "hello")))
+             , (MkFieldName "mst", ESome initFC $ (ETextLit initFC (MkChunks [] "hello")))
+             , (MkFieldName "mst2", (EApp initFC (ENone initFC) (EText initFC)))
              ])
 
 data ExADT1
@@ -60,22 +60,22 @@ Show ExADT1 where
 
 exADT1 : Maybe ExADT1
 exADT1 = fromDhall
-  (EApp (EField (EUnion $ fromList []) (MkFieldName "Foo")) $ ENaturalLit 3)
+  (EApp initFC (EField initFC (EUnion initFC $ fromList []) (MkFieldName "Foo")) $ ENaturalLit initFC 3)
 exADT2 : Maybe ExADT1
 exADT2 = fromDhall
-  (EApp (EField (EUnion $ fromList []) (MkFieldName "Bar")) $ EBoolLit True)
+  (EApp initFC (EField initFC (EUnion initFC $ fromList []) (MkFieldName "Bar")) $ EBoolLit initFC True)
 exADT3 : Maybe ExADT1
 exADT3 = fromDhall
-  (EApp (EField (EUnion $ fromList []) (MkFieldName "Baz")) $ ESome $ EBoolLit True)
+  (EApp initFC (EField initFC (EUnion initFC $ fromList []) (MkFieldName "Baz")) $ ESome initFC $ EBoolLit initFC True)
 
 exADT4 : Maybe ExADT1
 exADT4 = fromDhall
-        (EApp (EField
-          ( EUnion $ fromList
-            [ ((MkFieldName "Bar"), Just EBool)
-            , ((MkFieldName "Foo"), Just ENatural)
+        (EApp initFC (EField initFC
+          ( EUnion initFC $ fromList
+            [ ((MkFieldName "Bar"), Just $ EBool initFC)
+            , ((MkFieldName "Foo"), Just $ ENatural initFC)
             ]
-          ) (MkFieldName "Foo")) (ENaturalLit 3))
+          ) (MkFieldName "Foo")) (ENaturalLit initFC 3))
 
 putLines : Show a => List a -> IO ()
 putLines = putStrLn . fastAppend . (intersperse "\n") . map show


### PR DESCRIPTION
Adds parsers for all the grammar, though not particularly robust. Still using old parser, but next up is to use the new parser in the tests and see how far it is from parity with the current one.

This PR also adds a `FC` (file context) to `Expr`, `Value` and many other functions throughout. This will be a breaking change if you're depending on those types, but if you're using the `derive` API v2 interface then this should be a transparent change (at least I didn't have to edit the tests for eg. the inigo parser). Could be something I missed though.