### PR TITLE
Fix interpolated strings normalisation

### DIFF
--- a/Idrall/Eval.idr
+++ b/Idrall/Eval.idr
@@ -234,10 +234,10 @@ mutual
   eval env (EText fc) = pure $ VText fc
   eval env (ETextLit fc (MkChunks xs x)) = do
     xs' <- traverse (mapChunks (eval env)) xs
-    -- pure (VTextLit fc (MkVChunks xs' x))
-    case (xs', x) of
+    let xs'' = compressChunks xs'
+    case (xs'', x) of
          ([("", t)], "") => pure t
-         _ => pure (VTextLit fc (MkVChunks xs' x))
+         _ => pure (VTextLit fc (MkVChunks xs'' x))
   eval env (ETextAppend fc x y) =
     case (!(eval env x), !(eval env y)) of
          (VTextLit fc (MkVChunks [] ""), u) => pure u
@@ -583,6 +583,12 @@ mutual
 
   convErr : (Show x) => FC -> x -> x -> Either Error a
   convErr fc x y = Left $ AlphaEquivError fc $ show x ++ "\n not alpha equivalent to:\n" ++ show y
+
+  export
+  compressChunks : List (String, Value) -> List (String, Value)
+  compressChunks [] = []
+  compressChunks (("", (VTextLit _ (MkVChunks [] ""))) :: xs) = compressChunks xs
+  compressChunks (x :: xs) = x :: compressChunks xs
 
   export
   strFromExpr : Expr Void -> Maybe String

--- a/Idrall/Eval.idr
+++ b/Idrall/Eval.idr
@@ -234,7 +234,10 @@ mutual
   eval env (EText fc) = pure $ VText fc
   eval env (ETextLit fc (MkChunks xs x)) = do
     xs' <- traverse (mapChunks (eval env)) xs
-    pure (VTextLit fc (MkVChunks xs' x))
+    -- pure (VTextLit fc (MkVChunks xs' x))
+    case (xs', x) of
+         ([("", t)], "") => pure t
+         _ => pure (VTextLit fc (MkVChunks xs' x))
   eval env (ETextAppend fc x y) =
     case (!(eval env x), !(eval env y)) of
          (VTextLit fc (MkVChunks [] ""), u) => pure u

--- a/tests/idrall/idrall005/expected
+++ b/tests/idrall/idrall005/expected
@@ -442,22 +442,8 @@ Testing: ../../../dhall-lang/tests/normalization/success/unit/TextInterpolateA.d
 "sb"
 
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested1A.dhall
-0| λ(x: Text) → "${""}${x}"
-                ^^^^^^^^^^^
-
-../../../dhall-lang/tests/normalization/success/unit/TextLitNested1A.dhall:(0, 13)-(0, 24)AlphaEquivError: (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [] ""))), ("", (VVar "x" 0))] ""))
- not alpha equivalent to:
-(VVar "x" 0)
-
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested2A.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested3A.dhall
-0| λ(x: Text) → "${"${""}"}${x}"
-                ^^^^^^^^^^^^^^^^
-
-../../../dhall-lang/tests/normalization/success/unit/TextLitNested3A.dhall:(0, 13)-(0, 29)AlphaEquivError: (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [] ""))), ("", (VVar "x" 0))] ""))
- not alpha equivalent to:
-(VVar "x" 0)
-
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLiteralA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextNormalizeInterpolationsA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextReplaceAbstractA.dhall
@@ -517,6 +503,6 @@ Testing: ../../../dhall-lang/tests/normalization/success/unit/WithNestedA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/WithPartiallyAbstractA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/WithPriorityA.dhall
 Result:
-Pass: 227
-Fail: 42
+Pass: 229
+Fail: 40
 Main> Bye for now!

--- a/tests/idrall/idrall005/expected
+++ b/tests/idrall/idrall005/expected
@@ -66,13 +66,6 @@ Testing: ../../../dhall-lang/tests/normalization/success/simplifications/rightBi
 
 Testing: ../../../dhall-lang/tests/normalization/success/unit/AssertNormalizeArgumentA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/BareInterpolationA.dhall
-0| λ(x : Text) → "${x}"
-                 ^^^^^^
-
-../../../dhall-lang/tests/normalization/success/unit/BareInterpolationA.dhall:(0, 14)-(0, 20)AlphaEquivError: (VTextLit (MkVChunks [("", (VVar "x" 0))] ""))
- not alpha equivalent to:
-(VVar "x" 0)
-
 Testing: ../../../dhall-lang/tests/normalization/success/unit/BoolA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/CompletionA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/DoubleA.dhall
@@ -457,18 +450,11 @@ Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested1A.dh
 (VVar "x" 0)
 
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested2A.dhall
-0| λ(x: Text) → "${"${x}"}"
-                ^^^^^^^^^^^
-
-../../../dhall-lang/tests/normalization/success/unit/TextLitNested2A.dhall:(0, 13)-(0, 24)AlphaEquivError: (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [("", (VVar "x" 0))] "")))] ""))
- not alpha equivalent to:
-(VVar "x" 0)
-
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextLitNested3A.dhall
 0| λ(x: Text) → "${"${""}"}${x}"
                 ^^^^^^^^^^^^^^^^
 
-../../../dhall-lang/tests/normalization/success/unit/TextLitNested3A.dhall:(0, 13)-(0, 29)AlphaEquivError: (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [] "")))] ""))), ("", (VVar "x" 0))] ""))
+../../../dhall-lang/tests/normalization/success/unit/TextLitNested3A.dhall:(0, 13)-(0, 29)AlphaEquivError: (VTextLit (MkVChunks [("", (VTextLit (MkVChunks [] ""))), ("", (VVar "x" 0))] ""))
  not alpha equivalent to:
 (VVar "x" 0)
 
@@ -531,6 +517,6 @@ Testing: ../../../dhall-lang/tests/normalization/success/unit/WithNestedA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/WithPartiallyAbstractA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/WithPriorityA.dhall
 Result:
-Pass: 225
-Fail: 44
+Pass: 227
+Fail: 42
 Main> Bye for now!


### PR DESCRIPTION
Few extra passing tests for normalising string interpolation, mostly around normalising away empty strings.