### PR TITLE
Escape `\\`

### DIFF
--- a/Idrall/Parser/Rule.idr
+++ b/Idrall/Parser/Rule.idr
@@ -82,7 +82,7 @@ escapeSingle escapeChars (x :: xs) =
        ('t' :: xs) => escapeSingle escapeChars ('\t' :: xs)
        ('"' :: xs) => escapeSingle escapeChars ('"' :: xs)
        ('$' :: xs) => escapeSingle escapeChars ('$' :: xs)
-       ('\\' :: xs) => escapeSingle escapeChars ('\\' :: xs)
+       ('\\' :: xs) => pure $ '\\' :: !(escapeSingle escapeChars xs)
        ('/' :: xs) => escapeSingle escapeChars ('/' :: xs)
        -- TODO unicode
        _ => pure $ x :: !(escapeSingle escapeChars xs)

--- a/tests/idrall/idrall005/expected
+++ b/tests/idrall/idrall005/expected
@@ -479,9 +479,9 @@ Testing: ../../../dhall-lang/tests/normalization/success/unit/TextShowAllEscapes
 0| Text/show "\"\$\\\b\f\n\r\tツa\u0007b\u0010c"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-../../../dhall-lang/tests/normalization/success/unit/TextShowAllEscapesA.dhall:(0, 10)-(0, 44)AlphaEquivError: "\"\\\"\\u0024\\b\\f\\n\\r\\t\12484a\\\\u0007b\\\\u0010c\""
+../../../dhall-lang/tests/normalization/success/unit/TextShowAllEscapesA.dhall:(0, 10)-(0, 44)AlphaEquivError: "\"\\\"\\u0024\\\\\\b\\f\\n\\r\\t\12484a\\\\u0007b\\\\u0010c\""
  not alpha equivalent to:
-"\"\"\\u0024\b\f\n\r\t\12484a\\u0007b\\u0010c\""
+"\"\\\"\\u0024\\\\\\b\\f\\n\\r\\t\12484a\\u0007b\\u0010c\""
 
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextShowEmptyA.dhall
 Testing: ../../../dhall-lang/tests/normalization/success/unit/TextShowInterpolatedA.dhall


### PR DESCRIPTION
cc @ohad.

Had to open a new PR. Thanks for the suggestion! It seems to fix your `"\\test"` example. There's still the failing test in this diff from the unicode issue, so it's hard to be certain it hasn't caused other regressions, but hopefully it'll at least unblock your usecase.