### PR TITLE
Add simple `ToDhall` interface

### DIFF
--- a/Idrall/API/V2.idr
+++ b/Idrall/API/V2.idr
@@ -4,6 +4,7 @@ import Idrall.Value
 import public Idrall.Expr
 import public Idrall.Error
 import public Idrall.Derive
+import public Idrall.Derive.ToDhall
 import public Idrall.IOEither
 import Idrall.APIv1
 

--- a/Idrall/Derive/Common.idr
+++ b/Idrall/Derive/Common.idr
@@ -1,0 +1,104 @@
+module Idrall.Derive.Common
+
+import Language.Reflection
+import Data.List1
+import public Data.String
+
+%language ElabReflection
+
+%hide Data.List.lookup
+
+---------------------------------------------------
+-- from idris2-elab-util Language.Reflection.Syntax
+---------------------------------------------------
+
+||| Named type.
+|||
+||| This is an alias for `MkTyp EmptyFC`.
+export
+mkTy : (n : Name) -> (ty : TTImp) -> ITy
+mkTy = MkTy EmptyFC EmptyFC
+
+||| Creates a variable from the given name
+|||
+||| Names are best created using quotes: `{ AName },
+||| `{ In.Namespacs.Name }.
+|||
+||| Likewise, if the name is already known at the time of
+||| writing, use quotes for defining variables directly: `(AName)
+export
+var : Name -> TTImp
+var = IVar EmptyFC
+
+public export
+FromString Name where
+  fromString s = run (split ('.' ==) s) []
+    where run : List1 String -> List String -> Name
+          run (h ::: []) []        = UN $ Basic h
+          run (h ::: []) ns        = NS (MkNS ns) (UN $ Basic h)
+          run (h ::: (y :: ys)) xs = run (y ::: ys) (h :: xs)
+
+||| Alias for `var . fromString`
+export
+varStr : String -> TTImp
+varStr = var . fromString
+
+||| A pattern clause consisting of the left-hand and
+||| right-hand side of the pattern arrow "=>".
+|||
+||| This is an alias for `PatClause EmptyFC`.
+export
+patClause : (lhs : TTImp) -> (rhs : TTImp) -> Clause
+patClause = PatClause EmptyFC
+------
+
+||| from idris2-lsp
+stripNs : Name -> Name
+stripNs (NS _ x) = x
+stripNs x = x
+
+||| from idris2-lsp
+covering
+genReadableSym : String -> Elab Name
+genReadableSym hint = do
+  MN v i <- genSym hint
+    | _ => fail "cannot generate readable argument name"
+  pure $ UN $ Basic (v ++ show i)
+
+||| from idris2-lsp
+primStr : String -> TTImp
+primStr = IPrimVal EmptyFC . Str
+
+||| from idris2-lsp
+bindvar : String -> TTImp
+bindvar = IBindVar EmptyFC
+
+||| from idris2-lsp
+implicit' : TTImp
+implicit' = Implicit EmptyFC True
+
+||| moved from where clause
+getArgs : TTImp -> Elab (List (Name, TTImp))
+getArgs (IPi _ _ _ (Just n) argTy retTy) = ((n, argTy) ::) <$> getArgs retTy
+getArgs (IPi _ _ _ Nothing _ _) = fail $ "All arguments must be explicitly named"
+getArgs _ = pure []
+
+Cons : Type
+Cons = (List (Name, List (Name, TTImp)))
+
+logCons : Cons -> Elab ()
+logCons [] = pure ()
+logCons (x :: xs) = do
+  more x
+  logCons xs
+where
+  go : List (Name, TTImp) -> Elab ()
+  go [] =  pure ()
+  go ((n, t) :: ys) = do
+    logMsg "" 7 ("ArgName: " ++ show n)
+    logTerm "" 7 "ArgType" t
+    go ys
+  more : (Name, List (Name, TTImp)) -> Elab ()
+  more (constructor', args) = do
+    logMsg "" 7 ("Constructor: " ++ show constructor')
+    go args

--- a/Idrall/Derive/ToDhall.idr
+++ b/Idrall/Derive/ToDhall.idr
@@ -5,7 +5,6 @@ import Idrall.Error
 import Idrall.Pretty
 
 import public Data.SortedMap
-import Text.PrettyPrint.PrettyPrinter.Render.Terminal
 
 public export
 interface ToDhall ty where
@@ -51,12 +50,3 @@ ToDhall ty => ToDhall (Maybe ty) where
 export
 Pretty Void where
   pretty x = pretty ""
-
-testPretty : ToDhall ty => ty -> IO ()
-testPretty x =
-  let dhall = toDhall x
-  in case dhall of
-          (Left y) => do
-            putStrLn $ show y
-          (Right y) => do
-            putDoc $ pretty y

--- a/Idrall/Derive/ToDhall.idr
+++ b/Idrall/Derive/ToDhall.idr
@@ -1,0 +1,61 @@
+module Idrall.Derive.ToDhall
+
+import Idrall.Expr
+import Idrall.Error
+import Idrall.Pretty
+
+import public Data.SortedMap
+import Text.PrettyPrint.PrettyPrinter.Render.Terminal
+
+public export
+interface ToDhall ty where
+  toDhallType : Either Error (Expr Void)
+  toDhall : ty -> Either Error (Expr Void)
+
+export
+ToDhall Nat where
+  toDhallType = Right $ ENatural EmptyFC
+  toDhall x = Right $ ENaturalLit EmptyFC x
+
+export
+ToDhall Bool where
+  toDhallType = Right $ EBool EmptyFC
+  toDhall x = Right $ EBoolLit EmptyFC x
+
+export
+ToDhall Integer where
+  toDhallType = Right $ EInteger EmptyFC
+  toDhall x = Right $ EIntegerLit EmptyFC x
+
+export
+ToDhall Double where
+  toDhallType = Right $ EDouble EmptyFC
+  toDhall x = Right $ EDoubleLit EmptyFC x
+
+export
+ToDhall String where
+  toDhallType = Right $ EText EmptyFC
+  toDhall x = Right $ ETextLit EmptyFC (MkChunks [] x)
+
+export
+ToDhall ty => ToDhall (List ty) where
+  toDhallType = Right $ EApp EmptyFC (EList EmptyFC) !(toDhallType {ty=ty})
+  toDhall xs = Right $ EListLit EmptyFC (Just !(toDhallType {ty=ty})) !(traverse toDhall xs)
+
+export
+ToDhall ty => ToDhall (Maybe ty) where
+  toDhallType = Right $ EApp EmptyFC (EOptional EmptyFC) !(toDhallType {ty=ty})
+  toDhall Nothing = Right $ EApp EmptyFC (ENone EmptyFC) !(toDhallType {ty=Maybe ty})
+  toDhall (Just x) = Right $ ESome EmptyFC !(toDhall x)
+
+Pretty Void where
+  pretty x = pretty ""
+
+testPretty : ToDhall ty => ty -> IO ()
+testPretty x =
+  let dhall = toDhall x
+  in case dhall of
+          (Left y) => do
+            putStrLn $ show y
+          (Right y) => do
+            putDoc $ pretty y

--- a/Idrall/Derive/ToDhall.idr
+++ b/Idrall/Derive/ToDhall.idr
@@ -48,6 +48,7 @@ ToDhall ty => ToDhall (Maybe ty) where
   toDhall Nothing = Right $ EApp EmptyFC (ENone EmptyFC) !(toDhallType {ty=Maybe ty})
   toDhall (Just x) = Right $ ESome EmptyFC !(toDhall x)
 
+export
 Pretty Void where
   pretty x = pretty ""
 

--- a/Idrall/Derive/ToDhall.idr
+++ b/Idrall/Derive/ToDhall.idr
@@ -45,7 +45,7 @@ ToDhall ty => ToDhall (List ty) where
 export
 ToDhall ty => ToDhall (Maybe ty) where
   toDhallType = Right $ EApp EmptyFC (EOptional EmptyFC) !(toDhallType {ty=ty})
-  toDhall Nothing = Right $ EApp EmptyFC (ENone EmptyFC) !(toDhallType {ty=Maybe ty})
+  toDhall Nothing = Right $ EApp EmptyFC (ENone EmptyFC) !(toDhallType {ty=ty})
   toDhall (Just x) = Right $ ESome EmptyFC !(toDhall x)
 
 export

--- a/Idrall/Pretty.idr
+++ b/Idrall/Pretty.idr
@@ -14,6 +14,9 @@ prettyDottedList [] = pretty ""
 prettyDottedList (x :: []) = pretty x
 prettyDottedList (x :: xs) = pretty x <+> pretty "." <+> prettyDottedList xs
 
+sbraces : Doc ann -> Doc ann
+sbraces = enclose lbrace (space <+> rbrace)
+
 mutual
   prettySortedMap : Pretty x => Pretty y
                   => (Doc ann -> Doc ann)
@@ -36,7 +39,7 @@ mutual
     let ls = SortedMap.toList e
         lsDoc = map go ls
     in
-    enclose langle (space <+> rangle) $ foldl (<++>) neutral (punctuate (space <+> pipe) lsDoc)
+    enclose langle (space <++> rangle) $ foldl (<++>) neutral (punctuate (space <+> pipe) lsDoc)
   where
     go : (x, Maybe y) -> Doc ann
     go (s, Nothing) = pretty s
@@ -150,8 +153,8 @@ mutual
       prettyDottedList (forget xs) <++> equals <++> pretty y
     pretty (EEquivalent fc x y) = pretty x <++> pretty "===" <++> pretty y
     pretty (EAssert fc x) = pretty "assert" <++> colon <++> pretty x
-    pretty (ERecord fc x) = prettySortedMap braces colon x
-    pretty (ERecordLit fc x) = prettySortedMap braces equals x
+    pretty (ERecord fc x) = prettySortedMap sbraces colon x
+    pretty (ERecordLit fc x) = prettySortedMap sbraces equals x
     pretty (EUnion fc x) = prettyUnion x
     pretty (ECombine fc x y) = pretty x <++> pretty "/\\" <++> pretty y
     pretty (ECombineTypes fc x y) = pretty x <++> pretty "//\\\\" <++> pretty y

--- a/Idrall/Pretty.idr
+++ b/Idrall/Pretty.idr
@@ -74,7 +74,9 @@ mutual
 
   export
   Pretty a => Pretty (Chunks a) where
-    pretty (MkChunks xs x) = pretty xs <+> pretty x
+    pretty (MkChunks [] x) = dquotes $ pretty x
+    pretty (MkChunks (y :: xs) x) = dquotes $ pretty y <+> pretty xs <+> pretty x
+
 
   export
   Pretty a => Pretty (Expr a) where

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ repl: test-setup
 	rlwrap -n idris2 -p contrib Idrall/APIv1.idr
 
 repl2: test-setup
-	rlwrap -n idris2 -p contrib Idrall/ParserNew.idr
+	rlwrap -n idris2 -p contrib Idrall/Derive/ToDhall.idr
 
 edit-tests: test-setup
 	cd ./tests/idrall/idrall002 && rlwrap -n idris2 -p contrib -p test -p idrall All.idr

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ edit-tests-one: test-setup
 	cd ./tests/idrall/idrall004 && rlwrap -n idris2 -p contrib -p test -p idrall One.idr
 
 edit-tests-derive: test-setup
-	cd ./tests/derive/derive001 && rlwrap -n idris2 -p contrib -p test -p idrall Derive.idr
+	cd ./tests/derive/derive002 && rlwrap -n idris2 -p contrib -p test -p idrall Main.idr
 
 clean:
 	rm -f tests/*.idr~

--- a/idrall.ipkg
+++ b/idrall.ipkg
@@ -22,3 +22,4 @@ modules = Idrall.Expr
         , Idrall.API.V2
         , Idrall.Derive
         , Idrall.Pretty
+        , Idrall.Derive.ToDhall

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -32,6 +32,7 @@ failTests = MkTestPool "dhall-lang expected fail tests" [] Default
 deriveTests : TestPool
 deriveTests = MkTestPool "derive tests" [] Default
   [ "derive001"
+  , "derive002"
   ]
 
 examplesTests : TestPool

--- a/tests/derive/derive002/.gitignore
+++ b/tests/derive/derive002/.gitignore
@@ -1,0 +1,2 @@
+Package.idr
+package.dhall

--- a/tests/derive/derive002/Main.idr
+++ b/tests/derive/derive002/Main.idr
@@ -13,6 +13,15 @@ testPretty x =
           (Right y) => do
             putDoc $ pretty y
 
+record Foo where
+  constructor MkFoo
+  someNat : Nat
+
+ToDhall Foo where
+  toDhallType = Right $
+    ERecord EmptyFC $ fromList [ (MkFieldName "n", ENatural EmptyFC) ]
+  toDhall foo = Right $ ERecordLit EmptyFC $ fromList [ (MkFieldName "n", !(toDhall $ someNat foo)) ]
+
 main : IO ()
 main = do
   testPretty $ the (List Nat) [1,2,3]
@@ -21,3 +30,4 @@ main = do
   testPretty $ the (Maybe Bool) Nothing
   testPretty $ True
   testPretty $ 2.4
+  testPretty $ MkFoo 20

--- a/tests/derive/derive002/Main.idr
+++ b/tests/derive/derive002/Main.idr
@@ -1,0 +1,23 @@
+module Main
+
+import Idrall.API.V2
+import Idrall.Pretty
+import Text.PrettyPrint.PrettyPrinter.Render.Terminal
+
+testPretty : ToDhall ty => ty -> IO ()
+testPretty x =
+  let dhall = toDhall x
+  in case dhall of
+          (Left y) => do
+            putStrLn $ show y
+          (Right y) => do
+            putDoc $ pretty y
+
+main : IO ()
+main = do
+  testPretty $ the (List Nat) [1,2,3]
+  testPretty $ the (Integer) 10
+  testPretty $ Just "foo"
+  testPretty $ the (Maybe Bool) Nothing
+  testPretty $ True
+  testPretty $ 2.4

--- a/tests/derive/derive002/Main.idr
+++ b/tests/derive/derive002/Main.idr
@@ -2,7 +2,7 @@ module Main
 
 import Idrall.API.V2
 import Idrall.Pretty
-import Text.PrettyPrint.PrettyPrinter.Render.Terminal
+import Text.PrettyPrint.Prettyprinter.Render.Terminal
 
 testPretty : ToDhall ty => ty -> IO ()
 testPretty x =

--- a/tests/derive/derive002/expected
+++ b/tests/derive/derive002/expected
@@ -4,3 +4,4 @@ Some "foo"
 None Bool
 True
 2.4
+{ n = 20 }

--- a/tests/derive/derive002/expected
+++ b/tests/derive/derive002/expected
@@ -1,6 +1,6 @@
 [1, 2, 3] : Natural
 10
-Some []foo
-None Optional Bool
+Some "foo"
+None Bool
 True
 2.4

--- a/tests/derive/derive002/expected
+++ b/tests/derive/derive002/expected
@@ -1,0 +1,6 @@
+[1, 2, 3] : Natural
+10
+Some []foo
+None Optional Bool
+True
+2.4

--- a/tests/derive/derive002/run
+++ b/tests/derive/derive002/run
@@ -1,0 +1,3 @@
+idris2 --no-banner --no-color --console-width 0 -p contrib -p idrall Main.idr --exec main
+
+rm -rf build


### PR DESCRIPTION
Step 1 on the way to having a nice `ToDhall` interface.

Adds the following interface:
```
public export
interface ToDhall ty where
  toDhallType : Either Error (Expr Void)
  toDhall : ty -> Either Error (Expr Void)
```
See tests/derive/derive002/Main.idr for how this can be used to turn an simple idris value into a dhall `Expr`, that can then be pretty printed if so desired. It covers simple types pretty well, but the `record` example shows that's still pretty verbose. That can be made nicer using elaborator reflection, like how it's done for the `FromDhall` interface, and I hope to do that in future, but this'll have to do as an initial version.

The reason for having the `toDhallType` is that dhall doesn't have much type inference. For example, the values of `Optional Bool` in dhall, you'd need to write either `Some True` or `None Bool`, you can't just write `None`. As such, it needs to be possible to get the dhall types of idris values, should they need to be used in `Optional`s, `List`s, and a few other places.

cc @ohad 