### PR TITLE
Add parens around pretty printing of application

### DIFF
--- a/Idrall/Pretty.idr
+++ b/Idrall/Pretty.idr
@@ -85,7 +85,7 @@ mutual
   Pretty a => Pretty (Expr a) where
     pretty (EConst fc x) = pretty x
     pretty (EVar fc x n) = pretty x <+> pretty "@" <+> pretty n
-    pretty (EApp fc x y) = pretty x <++> pretty y
+    pretty (EApp fc x y) = pretty x <++> parens (pretty y)
     pretty (ELam fc n x y) =
       pretty "\\" <+> parens (pretty n <++> colon <++> pretty x)
         <++> pretty "->" <++> pretty y

--- a/tests/derive/derive002/expected
+++ b/tests/derive/derive002/expected
@@ -2,14 +2,14 @@
 [] : List Bool
 10
 Some "foo"
-None Bool
+None (Bool)
 True
 2.4
 { someNat = 20 }
-< ADouble : Double | Bar  >.ADouble 30.0
+< ADouble : Double | Bar  >.ADouble (30.0)
 < ADouble : Double | Bar  >.Bar
 { someList = [ 1.2
              , 3.4 ], someNat = 2, someNat1 = 3, someOpBool = Some True, someStr = "mkfoo" }
-< ADouble2 : Double | Bar2 | Baz : Optional Natural  >.ADouble2 40.0
-< ADouble2 : Double | Bar2 | Baz : Optional Natural  >.Bar2
-< ADouble2 : Double | Bar2 | Baz : Optional Natural  >.Baz Some 1
+< ADouble2 : Double | Bar2 | Baz : Optional (Natural)  >.ADouble2 (40.0)
+< ADouble2 : Double | Bar2 | Baz : Optional (Natural)  >.Bar2
+< ADouble2 : Double | Bar2 | Baz : Optional (Natural)  >.Baz (Some 1)


### PR DESCRIPTION
It's been really fun to explore Dhall via Idris interop so thanks for putting this library together!

I found that pretty printing _almost_ created valid Dhall if I had e.g. an Optional List of Naturals, but it lacked parentheses. This PR over-applies parentheses so that the result is always valid Dhall even if sometimes it has more parentheses than needed.

before:
```dhall
Optional List Text
```

after:
```dhall
Optional (List Text)
```