### PR TITLE
Allow transforming Idris record names for to/from Dhall

### DIFF
--- a/Idrall/Derive.idr
+++ b/Idrall/Derive.idr
@@ -74,8 +74,8 @@ Alternative (Either Error) where
   (Right x) <|> _ = (Right x)
 
 export
-deriveFromDhall : IdrisType -> (name : Name) -> Elab ()
-deriveFromDhall it n =
+deriveFromDhall : IdrisType -> {default Common.defaultOptions options : Options} -> (name : Name) -> Elab ()
+deriveFromDhall it {options} n =
   do [(name, _)] <- getType n
              | _ => fail "Ambiguous name"
      let funName = UN $ Basic ("fromDhall" ++ show (stripNs name))
@@ -119,7 +119,7 @@ deriveFromDhall it n =
     genClauseRecord : Name -> Name -> List (Name, TTImp) -> Elab (TTImp)
     genClauseRecord constructor' arg xs = do
           let rhs = foldr (\(n, type), acc =>
-                            let name = primStr $ (show n) in
+                            let name = primStr $ options.fieldNameModifier (show n) in
                                 case type of
                                      _ => `(~acc <*> (lookupEither ~(varStr "fc") (MkFieldName ~name) ~(var arg) >>= fromDhall)))
                           `(pure ~(var constructor')) xs

--- a/Idrall/Derive/Common.idr
+++ b/Idrall/Derive/Common.idr
@@ -118,3 +118,15 @@ public export
 data IdrisType
   = ADT
   | Record
+
+public export
+record Options where
+  constructor MkOptions
+  ||| This function is used to adjust constructor argument names
+  ||| during encoding and decoding
+  fieldNameModifier          : String -> String
+
+export
+defaultOptions : Options
+defaultOptions = MkOptions id
+


### PR DESCRIPTION
This is an idea I borrowed from Stefan's JSON deriving. The need I had was to allow an Idris record field named `ns` to serialize to Dhall as the name `namespace`. Since `namespace` is a reserved word in Idris, you need to choose some other name for the Idris record. Prior to having an option to transform record field names, it was necessary to implement the `ToDhall`/`FromDhall` methods from scratch. With this option, you can choose to take the default derived implementations _except_ for one or more field names. As described in the documentation for Stefan's JSON deriving, one use-case might be to take field names an uniformly transform them all (e.g. take the first 3 characters of each name). I found a more practical use-case to be renaming just one field out of many, which fortunately can be achieved via the same `fieldNameModifier` option.

For example:
```idris
record Resource where
  ns : String
  name : String

dhallOptions : Idrall.Derive.Common.Options
dhallOptions = { fieldNameModifier := \case "ns" => "namespace"; fieldName => fieldName } defaultOptions

%runElab deriveFromDhall Record {options=dhallOptions} `{ K8sMetadata }
%runElab deriveToDhall Record {options=dhallOptions} `{ K8sMetadata }
```

I gave the options a default value so that the existing derive call syntax remained valid.
