### PR TITLE
[ upstream ] Support `Name` in `IBindVar`

### DIFF
--- a/Idrall/Derive.idr
+++ b/Idrall/Derive.idr
@@ -130,7 +130,7 @@ deriveFromDhall it {options} n =
           debug = show $ constructor'
           debug2 = show $ map fst xs
           lhs0 = `(~(var funName) (EField _ (EUnion _ xs) (MkFieldName ~cn)))
-          lhs1 = `(~(var funName) (EApp fc (EField _ (EUnion _ xs) (MkFieldName ~cn)) ~(bindvar $ show arg)))
+          lhs1 = `(~(var funName) (EApp fc (EField _ (EUnion _ xs) (MkFieldName ~cn)) ~(bindvar arg)))
           -- TODO lhsN for data constructors with more than 0 or 1 args
           in do
           case xs of
@@ -146,5 +146,5 @@ deriveFromDhall it {options} n =
       -- given constructors, lookup names in dhall records for those constructors
       clausesRecord <- traverse (\(cn, as) => genClauseRecord cn arg (reverse as)) cons
       -- create clause from dhall to `Maybe a` using the above clauses as the rhs
-      pure $ pure $ patClause `(~(var funName) (ERecordLit fc ~(bindvar $ show arg)))
+      pure $ pure $ patClause `(~(var funName) (ERecordLit fc ~(bindvar arg)))
                               (foldl (\acc, x => `(~x)) `(Left $ FromDhallError ~(varStr "fc") "failed1") (clausesRecord)) -- not a real foldl, basically just passes that clausesRecord though, also doesn't support a record with no args

--- a/Idrall/Derive/Common.idr
+++ b/Idrall/Derive/Common.idr
@@ -74,7 +74,7 @@ primStr = IPrimVal EmptyFC . Str
 
 ||| from idris2-lsp
 export
-bindvar : String -> TTImp
+bindvar : Name -> TTImp
 bindvar = IBindVar EmptyFC
 
 ||| from idris2-lsp

--- a/Idrall/Derive/ToDhall.idr
+++ b/Idrall/Derive/ToDhall.idr
@@ -92,9 +92,9 @@ parameters (options : Options)
 
   genRecordLitClauses : Name -> Name -> Cons -> List Clause
   genRecordLitClauses funName arg [] = do
-    pure $ patClause `(~(var funName) ~(bindvar $ show arg)) (dhallRecLitFromRecArg arg [])
+    pure $ patClause `(~(var funName) ~(bindvar arg)) (dhallRecLitFromRecArg arg [])
   genRecordLitClauses funName arg ((n, ls) :: xs) = do
-    pure $ patClause `(~(var funName) ~(bindvar $ show arg)) (dhallRecLitFromRecArg arg ls)
+    pure $ patClause `(~(var funName) ~(bindvar arg)) (dhallRecLitFromRecArg arg ls)
 
   deriveToDhallRecord :  Name
                       -> Name
@@ -145,7 +145,7 @@ genClauseADT name funName constructor' xs =
          ((n, t) :: []) => do
             argName <- genReadableSym "arg"
             pure $ MkPair
-              `(~(var funName) (~(varStr cnShort) ~(bindvar $ show argName)))
+              `(~(var funName) (~(varStr cnShort) ~(bindvar argName)))
               `(EApp EmptyFC (EField EmptyFC (~(varStr toDhallTypeFunName)) (MkFieldName ~fieldName)) (toDhall ~(var argName)))
          (x :: _) => fail $ "too many args for constructor: " ++ show constructor'
 


### PR DESCRIPTION
Fix following https://github.com/idris-lang/Idris2/pull/3526

Note: `IBindVar` is also used in [Idrall/Interfaces.idr](https://github.com/alexhumphreys/idrall/blob/main/Idrall/Interfaces.idr), but this file doesn't seem to be used in the build, and it also doesn't build for other reasons. In particular, it imports a non-existent `Idrall.Syntax`.
